### PR TITLE
Add 1rem padding to root of the EmptyState component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   Added `chevronColor` property onto `<InfoListItem>`.
 -   Added `chevronIcon` class for `chevron` element in `<InfoListItem>`.
+-   Added 1rem default padding to the root styles of `<EmptyState>`. ([#320](https://github.com/brightlayer-ui/react-component-library/issues/320))
 
 ## v5.3.3 (December 6, 2021)
 

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -27,14 +27,13 @@ export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
 
 const useStyles = makeStyles((theme) => ({
     root: {
-        height: '100%',
         color: theme.palette.text.primary,
-        minHeight: '100%',
         display: 'flex',
         justifyContent: 'center',
         flexDirection: 'column',
         textAlign: 'center',
         alignItems: 'center',
+        padding: '1rem',
     },
     icon: {
         color: theme.palette.text.secondary,

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -28,6 +28,8 @@ export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
 const useStyles = makeStyles((theme) => ({
     root: {
         color: theme.palette.text.primary,
+        height: '100%',
+        minHeight: '100%',
         display: 'flex',
         justifyContent: 'center',
         flexDirection: 'column',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #320.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add 1rem padding to root of the `EmptyState` component
- Removes 100% height and min-height styles from root of the `EmptyState` component

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![Screen Shot 2022-01-12 at 2 36 46 PM](https://user-images.githubusercontent.com/13989985/149209648-eb59db8b-8266-4619-8c4d-c079e60e2df1.png)

