### PR TITLE
Feature/2480 add chevron color to drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+-   Added `chevronColor` property onto `<Drawer>`.
+-   Added `chevron` class onto `<DrawerNavItem>`.
 -   Added `chevronColor` property onto `<InfoListItem>`.
 -   Added `chevron` class onto `<InfoListItem>`.
 -   Added `titleDivider` property onto `<DrawerNavGroup>`. ([#315](https://github.com/brightlayer-ui/react-component-library/issues/315))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,8 @@
 
 ### Added
 
--   Added `chevronColor` property onto `<Drawer>`.
--   Added `chevron` class onto `<DrawerNavItem>`.
--   Added `chevronColor` property onto `<InfoListItem>`.
--   Added `chevron` class onto `<InfoListItem>`.
+-   Added `chevronColor` property to `<InfoListItem>` and SharedProps of `<Drawer>`.
+-   Added class override for `chevron` on `<InfoListItem>` and `<DrawerNavItem>`.
 -   Added `titleDivider` property onto `<DrawerNavGroup>`. ([#315](https://github.com/brightlayer-ui/react-component-library/issues/315))
 -   Added 1rem default padding to the root styles of `<EmptyState>`. ([#320](https://github.com/brightlayer-ui/react-component-library/issues/320))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 -   Added `chevronColor` property onto `<InfoListItem>`.
--   Added `chevronIcon` class for `chevron` element in `<InfoListItem>`.
+-   Added `chevron` class onto `<InfoListItem>`.
 -   Added 1rem default padding to the root styles of `<EmptyState>`. ([#320](https://github.com/brightlayer-ui/react-component-library/issues/320))
 
 ## v5.3.3 (December 6, 2021)

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -142,6 +142,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
         activeItemIconColor,
         backgroundColor,
         chevron,
+        chevronColor,
         collapseIcon,
         disableActiveItemParentStyles,
         divider,
@@ -212,6 +213,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
                         activeItemIconColor: mergeStyleProp(activeItemIconColor, child.props.activeItemIconColor),
                         backgroundColor: mergeStyleProp(backgroundColor, child.props.backgroundColor),
                         chevron: mergeStyleProp(chevron, child.props.chevron),
+                        chevronColor: mergeStyleProp(chevronColor, child.props.chevronColor),
                         collapseIcon: mergeStyleProp(collapseIcon, child.props.collapseIcon),
                         disableActiveItemParentStyles: mergeStyleProp(
                             disableActiveItemParentStyles,
@@ -233,6 +235,7 @@ const DrawerRenderer: React.ForwardRefRenderFunction<unknown, DrawerProps> = (pr
             activeItemFontColor,
             activeItemIconColor,
             chevron,
+            chevronColor,
             collapseIcon,
             disableActiveItemParentStyles,
             divider,

--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -40,6 +40,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         activeItemIconColor,
         backgroundColor,
         chevron,
+        chevronColor,
         collapseIcon,
         disableActiveItemParentStyles,
         divider,
@@ -85,6 +86,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
                         activeItemIconColor={mergeStyleProp(activeItemIconColor, groupProps.activeItemIconColor)}
                         backgroundColor={mergeStyleProp(backgroundColor, groupProps.backgroundColor)}
                         chevron={mergeStyleProp(chevron, groupProps.chevron)}
+                        chevronColor={mergeStyleProp(chevronColor, child.props.chevronColor)}
                         collapseIcon={mergeStyleProp(collapseIcon, groupProps.collapseIcon)}
                         disableActiveItemParentStyles={mergeStyleProp(
                             disableActiveItemParentStyles,

--- a/components/src/core/Drawer/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup.tsx
@@ -117,6 +117,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
         activeItemIconColor,
         backgroundColor,
         chevron,
+        chevronColor,
         collapseIcon,
         disableActiveItemParentStyles,
         divider,
@@ -161,6 +162,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                               activeItemIconColor: mergeStyleProp(activeItemIconColor, child.props.activeItemIconColor),
                               backgroundColor: mergeStyleProp(backgroundColor, child.props.backgroundColor),
                               chevron: mergeStyleProp(chevron, child.props.chevron),
+                              chevronColor: mergeStyleProp(chevronColor, child.props.chevronColor),
                               collapseIcon: mergeStyleProp(collapseIcon, child.props.collapseIcon),
                               disableActiveItemParentStyles: mergeStyleProp(
                                   disableActiveItemParentStyles,
@@ -209,6 +211,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
             activeItemIconColor,
             backgroundColor,
             chevron,
+            chevronColor,
             collapseIcon,
             disableActiveItemParentStyles,
             divider,
@@ -314,6 +317,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                             activeItemIconColor={mergeStyleProp(activeItemIconColor, navItem.activeItemIconColor)}
                             backgroundColor={mergeStyleProp(backgroundColor, navItem.backgroundColor)}
                             chevron={mergeStyleProp(chevron, navItem.chevron)}
+                            chevronColor={mergeStyleProp(chevronColor, navItem.chevronColor)}
                             collapseIcon={mergeStyleProp(collapseIcon, navItem.collapseIcon)}
                             disableActiveItemParentStyles={mergeStyleProp(
                                 disableActiveItemParentStyles,

--- a/components/src/core/Drawer/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem.tsx
@@ -89,6 +89,11 @@ export type NestedNavItem = NestedDrawerNavItemProps;
 const calcNestedPadding = (theme: Theme, depth: number): number =>
     theme.spacing(depth ? (depth - 1) * 4 : 0) + theme.spacing(2);
 
+const getChevronColor = (props: DrawerNavItemProps, theme: Theme): string => {
+    const { chevronColor } = props;
+    return chevronColor ? chevronColor : theme.palette.text.secondary;
+};
+
 const useStyles = makeStyles((theme: Theme) =>
     createStyles({
         active: {
@@ -105,6 +110,9 @@ const useStyles = makeStyles((theme: Theme) =>
                 width: '100%',
                 borderRadius: 0,
             },
+        },
+        chevron: {
+            color: (props) => getChevronColor(props, theme),
         },
         drawerOpen: {},
         expanded: {},
@@ -209,6 +217,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         activeItemIconColor = theme.palette.type === 'light' ? theme.palette.primary.main : lightenedPrimary,
         backgroundColor,
         chevron,
+        chevronColor,
         children,
         classes = {},
         collapseIcon,
@@ -229,7 +238,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         notifyActiveParent = (): void => {},
         onClick,
         rightComponent = props.chevron && !props.items && !props.children ? (
-            <ChevronRight className={defaultClasses.flipIcon} />
+            <ChevronRight className={clsx(defaultClasses.chevron, defaultClasses.flipIcon)} />
         ) : undefined,
         ripple = true,
         statusColor,
@@ -329,6 +338,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                               activeItemIconColor: mergeStyleProp(activeItemIconColor, child.props.activeItemIconColor),
                               backgroundColor: mergeStyleProp(backgroundColor, child.props.backgroundColor),
                               chevron: mergeStyleProp(chevron, child.props.chevron),
+                              chevronColor: mergeStyleProp(chevronColor, child.props.chevronColor),
                               // we use props. because we don't want to pass the destructured default as the value to children
                               collapseIcon: mergeStyleProp(props.collapseIcon, child.props.collapseIcon),
                               disableActiveItemParentStyles: mergeStyleProp(
@@ -376,6 +386,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             activeHierarchy,
             backgroundColor,
             chevron,
+            chevronColor,
             collapseIcon,
             disableActiveItemParentStyles,
             divider,
@@ -486,6 +497,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                                     )}
                                     backgroundColor={mergeStyleProp(backgroundColor, subItem.backgroundColor)}
                                     chevron={mergeStyleProp(chevron, subItem.chevron)}
+                                    chevronColor={mergeStyleProp(chevronColor, subItem.chevronColor)}
                                     // we use props. because we don't want to pass the destructured default as the value to the children
                                     collapseIcon={mergeStyleProp(props.collapseIcon, subItem.collapseIcon)}
                                     disableActiveItemParentStyles={mergeStyleProp(

--- a/components/src/core/Drawer/types.tsx
+++ b/components/src/core/Drawer/types.tsx
@@ -45,6 +45,9 @@ export type NavItemSharedStyleProps = {
     /** Whether to have chevrons for all menu items */
     chevron?: boolean;
 
+    /** Color override for the chevron icon */
+    chevronColor?: string;
+
     /** Icon used to collapse nav group
      *
      * Default: expandIcon rotated 180 degrees
@@ -81,6 +84,7 @@ export const SharedStylePropTypes = {
 export const NavItemSharedStylePropTypes = {
     activeItemBackgroundShape: PropTypes.oneOf(['round', 'square']),
     chevron: PropTypes.bool,
+    chevronColor: PropTypes.string,
     collapseIcon: PropTypes.element,
     expandIcon: PropTypes.element,
     hidePadding: PropTypes.bool,

--- a/components/src/core/InfoListItem/InfoListItem.styles.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.styles.tsx
@@ -15,7 +15,7 @@ export type InfoListItemClasses = {
     statusStripe?: string;
     subtitle?: string;
     title?: string;
-    chevronIcon?: string;
+    chevron?: string;
 };
 
 const getHeight = (props: InfoListItemProps): string => (props.dense ? `3.25rem` : `4.5rem`);
@@ -113,7 +113,7 @@ export const useStyles = makeStyles<Theme, InfoListItemProps>((theme: Theme) =>
             display: 'flex',
             alignItems: 'center',
         },
-        chevronIcon: {
+        chevron: {
             color: (props) => getChevronColor(props, theme),
         },
         separator: {

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -29,6 +29,8 @@ export type InfoListItemProps = Omit<ListItemProps, 'title' | 'divider'> & {
      * Default: false
      */
     chevron?: boolean;
+    /** Color override for the chevron icon */
+    chevronColor?: string;
     /** Custom classes for default style overrides */
     classes?: InfoListItemClasses;
     /** Show a row separator below the row */
@@ -86,8 +88,6 @@ export type InfoListItemProps = Omit<ListItemProps, 'title' | 'divider'> & {
      * Default: false
      */
     wrapTitle?: boolean;
-    /** Color override for the chevron icon */
-    chevronColor?: string;
 };
 const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemProps> = (
     props: InfoListItemProps,
@@ -98,6 +98,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         avatar,
         button,
         chevron,
+        chevronColor,
         classes,
         divider,
         hidePadding,
@@ -119,7 +120,6 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         iconAlign,
         iconColor,
         statusColor,
-        chevronColor,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...otherListItemProps
     } = props;

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -98,7 +98,6 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         avatar,
         button,
         chevron,
-        chevronColor,
         classes,
         divider,
         hidePadding,
@@ -116,6 +115,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
         backgroundColor,
+        chevronColor,
         fontColor,
         iconAlign,
         iconColor,

--- a/components/src/core/InfoListItem/InfoListItem.tsx
+++ b/components/src/core/InfoListItem/InfoListItem.tsx
@@ -154,7 +154,7 @@ const InfoListItemRender: React.ForwardRefRenderFunction<unknown, InfoListItemPr
                 <Chevron
                     color={'inherit'}
                     role={'button'}
-                    className={clsx(combine('chevronIcon'), defaultClasses.flipIcon)}
+                    className={clsx(combine('chevron'), defaultClasses.flipIcon)}
                 />
             );
         }
@@ -261,7 +261,7 @@ InfoListItem.propTypes = {
         avatar: PropTypes.string,
         icon: PropTypes.string,
         rightComponent: PropTypes.string,
-        chevronIcon: PropTypes.string,
+        chevron: PropTypes.string,
         separator: PropTypes.string,
         subtitle: PropTypes.string,
         title: PropTypes.string,

--- a/demos/storybook/stories/drawer/with-full-config.tsx
+++ b/demos/storybook/stories/drawer/with-full-config.tsx
@@ -102,6 +102,7 @@ export const withFullConfig = (): StoryFnReactReturnType => {
         activeItemIconColor: color('activeItemIconColor', Colors.blue[500], drawerGroupId),
         activeItemBackgroundShape: select('activeItemBackgroundShape', ['round', 'square'], 'square', drawerGroupId),
         chevron: boolean('chevron', false, drawerGroupId),
+        chevronColor: color('chevronColor', Colors.gray[500], drawerGroupId),
         collapseIcon: getIcon(
             select('collapseIcon', ['undefined', '<Remove />', '<AddAPhoto />'], 'undefined', drawerGroupId)
         ),
@@ -316,6 +317,7 @@ export const withFullConfig = (): StoryFnReactReturnType => {
             activeItemIconColor={drawerKnobs.activeItemIconColor}
             activeItemBackgroundShape={drawerKnobs.activeItemBackgroundShape}
             chevron={drawerKnobs.chevron}
+            chevronColor={drawerKnobs.chevronColor}
             collapseIcon={drawerKnobs.collapseIcon}
             condensed={drawerKnobs.condensed}
             divider={drawerKnobs.divider}

--- a/demos/storybook/stories/info-list-item/with-full-config.tsx
+++ b/demos/storybook/stories/info-list-item/with-full-config.tsx
@@ -26,6 +26,7 @@ export const withFullConfig = (): StoryFnReactReturnType => {
             backgroundColor={color('backgroundColor', Colors.white[50])}
             avatar={boolean('avatar', false)}
             chevron={boolean('chevron', true)}
+            chevronColor={color('chevronColor', Colors.gray[500])}
             dense={boolean('dense', false)}
             divider={appliedDivider}
             ripple={boolean('ripple', false)}

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -320,6 +320,7 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | ---------------- | --------------------------------------------------------------- |
 | root             | Styles applied to the root element wrapping the InfoListItem    |
 | active           | Styles applied to the active item highlight element             |
+| chevron          | Styles applied to the chevron element                           |
 | expandIcon       | Styles applied to the expand/collapse icon wrapper              |
 | infoListItemRoot | Styles applied to the InfoListItem root element                 |
 | nestedListGroup  | Styles applied to wrapper surrounded nested children            |
@@ -449,6 +450,7 @@ The following are additional shared props that will apply when using a non-rail 
 | ----------------------------- | ----------------------------------------------------------------------------- | ----------------------- | -------- | ------------------------------------------------------------ |
 | activeItemBackgroundShape     | shape of the active item background highlight                                 | `'round'` \| `'square'` | no       | square                                                       |
 | chevron                       | Whether to have chevrons for all menu items                                   | `boolean`               | no       |                                                              |
+| chevronColor                  | Color override for the chevron icon                                           | `string`                | no       |                                                              |
 | collapseIcon                  | Icon used to collapse drawer                                                  | `JSX.Element`           | no       | `expandIcon` rotated 180 degrees                             |
 | expandIcon                    | Icon used to expand drawer                                                    | `JSX.Element`           | no       | `<ExpandMore />` at top-level, `<ArrowDropDown />` otherwise |
 | hidePadding                   | Whether to hide the paddings reserved for menu item icons                     | `boolean`               | no       |                                                              |

--- a/docs/InfoListItem.md
+++ b/docs/InfoListItem.md
@@ -63,7 +63,7 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | -------------- | --------------------------------------------------- |
 | root           | Styles applied to the root element                  |
 | avatar         | Styles applied to the Avatar element                |
-| chevronIcon    | Styles applied to the chevron element               |
+| chevron        | Styles applied to the chevron element               |
 | divider        | Styles applied to the divider element               |
 | icon           | Styles applied to the icon element                  |
 | info           | Styles applied to the third line of text element    |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #327 (Same for Drawer)

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added chevronColor prop to Drawer
- Added chevron class to DrawerNavItem

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Changed color using prop
<img width="1792" alt="Screenshot 2022-01-17 at 4 38 45 PM" src="https://user-images.githubusercontent.com/25982779/149759295-189b6a32-e408-4060-b62b-7a606dfe9e19.png">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:storybook
- Navigate to Drawer and open full config story
- Enable chevron and change chevronColor
