### PR TITLE
Blui 2923 migrate to updated image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,14 @@ version: 2.1
 orbs:
     codecov: codecov/codecov@1.1.3
     gh: circleci/github-cli@1.0.3
+    browser-tools: circleci/browser-tools@1.2.4
 jobs:
     build_library:
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: cimg/node:14.19.0-browsers
         steps:
             - checkout
+            - browser-tools/install-browser-tools
             - restore_cache:
                   keys:
                       - v2-dependencies-react-{{ checksum "components/yarn.lock" }}
@@ -59,7 +61,7 @@ jobs:
     coverage_report:
         working_directory: ~/react-component-library
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: cimg/node:14.19.0-browsers
         steps:
             - checkout
             - attach_workspace:
@@ -71,7 +73,7 @@ jobs:
     # Builds the Storybook app using @brightlayer-ui/react-components persisted in /dist folder.
     build_storybook:
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: cimg/node:14.19.0-browsers
         environment:
             - MASTER_BRANCH: master
             - DEV_BRANCH: dev
@@ -133,7 +135,7 @@ jobs:
     # Builds the Showcase app using @brightlayer-ui/react-components persisted in /dist folder.
     build_showcase:
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: cimg/node:14.19.0-browsers
         environment:
             - MASTER_BRANCH: master
         steps:
@@ -178,7 +180,7 @@ jobs:
 
     deploy_storybook:
         docker:
-            - image: circleci/node:12.9.1-browsers
+            - image: cimg/node:14.19.0-browsers
         environment:
             - MASTER_BRANCH: master
             - DEV_BRANCH: dev
@@ -216,7 +218,7 @@ jobs:
                       git push
     publish:
       docker:
-        - image: circleci/node:12.9.1-browsers
+        - image: cimg/node:14.19.0-browsers
       steps:
         - checkout
         - attach_workspace:
@@ -233,7 +235,7 @@ jobs:
 
     tag:
       docker:
-        - image: circleci/node:12.9.1-browsers
+        - image: cimg/node:14.19.0-browsers
       steps:
         - checkout
         - attach_workspace:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Migrating to next-gen Convenience Images
- use browser-tools: circleci/browser-tools@1.2.4 orb
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- 
