### PR TITLE
Update ChannelValue to use Mui v5 styles

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -14,6 +14,7 @@
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
         "@brightlayer-ui/colors": "^3.0.0",
+        "@emotion/css": "^11.9.0",
         "@seznam/compose-react-refs": "^1.0.6",
         "color": "^4.2.1"
     },

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -7,7 +7,9 @@ import { styled } from '@mui/material/styles';
 import channelValueClasses, { ChannelValueClasses, getChannelValueUtilityClass } from './ChannelValueClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-const useUtilityClasses = (ownerState: ChannelValueProps): any => {
+const useUtilityClasses = (
+    ownerState: ChannelValueProps
+): Record<'text' | 'prefix' | 'root' | 'icon' | 'suffix' | 'value' | 'units', string> => {
     const { classes } = ownerState;
 
     const slots = {

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -116,7 +116,6 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         ...props,
     };
     const defaultClasses = useUtilityClasses(ownerState);
-    console.log('typeof default classes: ', typeof defaultClasses);
     const prefixUnitAllowSpaceList = ['$'];
     const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
 

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -7,7 +7,7 @@ import { styled } from '@mui/material/styles';
 import channelValueClasses, { ChannelValueClasses, getChannelValueUtilityClass } from './ChannelValueClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-const useUtilityClasses = (ownerState: any) => {
+const useUtilityClasses = (ownerState: ChannelValueProps): any => {
     const { classes } = ownerState;
 
     const slots = {
@@ -116,6 +116,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         ...props,
     };
     const defaultClasses = useUtilityClasses(ownerState);
+    console.log('typeof default classes: ', typeof defaultClasses);
     const prefixUnitAllowSpaceList = ['$'];
     const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
 
@@ -138,10 +139,20 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                     <Typography
                         variant={'h6'}
                         color={'inherit'}
-                        className={cx(defaultClasses.text, defaultClasses.units, classes.units, {
-                            [defaultClasses.prefix]: applyPrefix(),
-                            [defaultClasses.suffix]: applySuffix(),
-                        })}
+                        className={cx(
+                            defaultClasses.text,
+                            classes.text,
+                            defaultClasses.units,
+                            classes.units,
+                            {
+                                [defaultClasses.prefix]: applyPrefix(),
+                                [defaultClasses.suffix]: applySuffix(),
+                            },
+                            {
+                                [classes.prefix]: applyPrefix(),
+                                [classes.suffix]: applySuffix(),
+                            }
+                        )}
                         data-test={'units'}
                     >
                         {units}
@@ -171,7 +182,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
             <Typography
                 variant={'h6'}
                 color={'inherit'}
-                className={cx(defaultClasses.text, defaultClasses.value, classes.value)}
+                className={cx(defaultClasses.text, classes.text, defaultClasses.value, classes.value)}
                 data-test={'value'}
             >
                 {value}

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -4,12 +4,14 @@ import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
 import { Box, BoxProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import channelValueClasses, { ChannelValueClasses, getChannelValueUtilityClass } from './ChannelValueClasses';
+import channelValueClasses, {
+    ChannelValueClasses,
+    ChannelValueClassKey,
+    getChannelValueUtilityClass,
+} from './ChannelValueClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-const useUtilityClasses = (
-    ownerState: ChannelValueProps
-): Record<'text' | 'prefix' | 'root' | 'icon' | 'suffix' | 'value' | 'units', string> => {
+const useUtilityClasses = (ownerState: ChannelValueProps): Record<ChannelValueClassKey, string> => {
     const { classes } = ownerState;
 
     const slots = {
@@ -114,10 +116,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...otherProps
     } = props;
-    const ownerState = {
-        ...props,
-    };
-    const defaultClasses = useUtilityClasses(ownerState);
+    const defaultClasses = useUtilityClasses(props);
     const prefixUnitAllowSpaceList = ['$'];
     const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
 

--- a/components/src/core/ChannelValue/ChannelValueClasses.tsx
+++ b/components/src/core/ChannelValue/ChannelValueClasses.tsx
@@ -1,6 +1,6 @@
 import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
 
-export interface ChannelValueClasses {
+export type ChannelValueClasses = {
     /** Styles applied to the root element. */
     root?: string;
     /** Styles applied to the icon element. */
@@ -15,7 +15,7 @@ export interface ChannelValueClasses {
     units?: string;
     /** Styles applied to the value element. */
     value?: string;
-}
+};
 
 export type ChannelValueClassKey = keyof ChannelValueClasses;
 

--- a/components/src/core/ChannelValue/ChannelValueClasses.tsx
+++ b/components/src/core/ChannelValue/ChannelValueClasses.tsx
@@ -1,0 +1,36 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export interface ChannelValueClasses {
+    /** Styles applied to the root element. */
+    root?: string;
+    /** Styles applied to the icon element. */
+    icon?: string;
+    /** Styles applied to the text element. */
+    text?: string;
+    /** Styles applied to the prefix element. */
+    prefix?: string;
+    /** Styles applied to the suffix element. */
+    suffix?: string;
+    /** Styles applied to the units element. */
+    units?: string;
+    /** Styles applied to the value element. */
+    value?: string;
+}
+
+export type ChannelValueClassKey = keyof ChannelValueClasses;
+
+export function getChannelValueUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiChannelValue', slot);
+}
+
+const channelValueClasses: ChannelValueClasses = generateUtilityClasses('BluiChannelValue', [
+    'root',
+    'icon',
+    'text',
+    'prefix',
+    'suffix',
+    'units',
+    'value',
+]);
+
+export default channelValueClasses;

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -372,6 +372,17 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
+"@emotion/css@^11.9.0":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.9.0.tgz#d5aeaca5ed19fc61cbdc9e032ad0b32fa6e366be"
+  integrity sha512-S9UjCxSrxEHawOLnWw4upTwfYKb0gVQdatHejn3W9kPyXxmKv3HmjVfJ84kDLmdX8jR20OuDQwaJ4Um24qD9vA==
+  dependencies:
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/serialize" "^1.0.3"
+    "@emotion/sheet" "^1.0.3"
+    "@emotion/utils" "^1.0.0"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -413,7 +424,18 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.1.0":
+"@emotion/serialize@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.3.tgz#99e2060c26c6292469fb30db41f4690e1c8fea63"
+  integrity sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.3", "@emotion/sheet@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -43,9 +43,40 @@ Any other props supplied will be provided to the root element (`span`).
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. It supports the following keys:
 
-| Name  | Description                         |
-| ----- | ----------------------------------- |
-| root  | Styles applied to the root element  |
-| icon  | Styles applied to the icon element  |
-| units | Styles applied to the units element |
-| value | Styles applied to the value element |
+| Name   | Description                          |
+| ------ | ------------------------------------ |
+| root   | Styles applied to the root element   |
+| icon   | Styles applied to the icon element   |
+| text   | Styles applied to the text element   |
+| prefix | Styles applied to the prefix element |
+| suffix | Styles applied to the suffix element |
+| units  | Styles applied to the units element  |
+| value  | Styles applied to the value element  |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop. It supports the following classNames:
+
+| Selector                 | Description                          |
+| ------------------------ | ------------------------------------ |
+| .BluiChannelValue-icon   | Styles applied to the icon element   |
+| .BluiChannelValue-text   | Styles applied to the text element   |
+| .BluiChannelValue-prefix | Styles applied to the prefix element |
+| .BluiChannelValue-suffix | Styles applied to the suffix element |
+| .BluiChannelValue-units  | Styles applied to the units element  |
+| .BluiChannelValue-value  | Styles applied to the value element  |
+
+```tsx
+import { ChannelValue } from '@brightlayer-ui/react-components';
+...
+<ChannelValue
+    value={100}
+    units={'%'}
+    icon={<Icon/>}
+    sx={{
+        ml: 1,
+        mr: 1,
+        '& .BluiChannelValue-icon': { ml: '2px', fontSize: '1rem' }
+    }}
+/>
+```

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -43,28 +43,28 @@ Any other props supplied will be provided to the root element (`span`).
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. It supports the following keys:
 
-| Name   | Description                          |
-| ------ | ------------------------------------ |
-| root   | Styles applied to the root element   |
-| icon   | Styles applied to the icon element   |
-| text   | Styles applied to the text element   |
-| prefix | Styles applied to the prefix element |
-| suffix | Styles applied to the suffix element |
-| units  | Styles applied to the units element  |
-| value  | Styles applied to the value element  |
+| Name   | Description                                               |
+| ------ | --------------------------------------------------------- |
+| root   | Styles applied to the root element                        |
+| icon   | Styles applied to the icon element                        |
+| text   | Styles applied to the text element                        |
+| prefix | Styles applied to the units element when used as a prefix |
+| suffix | Styles applied to the units element when used as a suffix |
+| units  | Styles applied to the units element                       |
+| value  | Styles applied to the value element                       |
 
 ### `sx` Class Overrides
 
 You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop. It supports the following classNames:
 
-| Selector                 | Description                          |
-| ------------------------ | ------------------------------------ |
-| .BluiChannelValue-icon   | Styles applied to the icon element   |
-| .BluiChannelValue-text   | Styles applied to the text element   |
-| .BluiChannelValue-prefix | Styles applied to the prefix element |
-| .BluiChannelValue-suffix | Styles applied to the suffix element |
-| .BluiChannelValue-units  | Styles applied to the units element  |
-| .BluiChannelValue-value  | Styles applied to the value element  |
+| Global CSS Class         | Description                                               |
+| ------------------------ | --------------------------------------------------------- |
+| .BluiChannelValue-icon   | Styles applied to the icon element                        |
+| .BluiChannelValue-text   | Styles applied to the text element                        |
+| .BluiChannelValue-prefix | Styles applied to the units element when used as a prefix |
+| .BluiChannelValue-suffix | Styles applied to the units element when used as a suffix |
+| .BluiChannelValue-units  | Styles applied to the units element                       |
+| .BluiChannelValue-value  | Styles applied to the value element                       |
 
 ```tsx
 import { ChannelValue } from '@brightlayer-ui/react-components';

--- a/scripts/linkComponents.sh
+++ b/scripts/linkComponents.sh
@@ -15,10 +15,11 @@ yarn build
 cd ..
 
 echo -en "${BLUE}Creating new folder in node_modules...${NC}"
-rm -rf "./demos/showcase/node_modules/@brightlayer-ui/react-components"
-mkdir -p "./demos/showcase/node_modules/@brightlayer-ui/react-components"
-rm -rf "./demos/storybook/node_modules/@brightlayer-ui/react-components"
-mkdir -p "./demos/storybook/node_modules/@brightlayer-ui/react-components"
+rm -rf ./demos/showcase/node_modules/.cache
+rm -rf ./demos/showcase/node_modules/@brightlayer-ui/react-components
+mkdir -p ./demos/showcase/node_modules/@brightlayer-ui/react-components
+rm -rf ./demos/storybook/node_modules/@brightlayer-ui/react-components
+mkdir -p ./demos/storybook/node_modules/@brightlayer-ui/react-components
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying build output into node_modules...${NC}";

--- a/scripts/linkComponents.sh
+++ b/scripts/linkComponents.sh
@@ -15,33 +15,33 @@ yarn build
 cd ..
 
 echo -en "${BLUE}Creating new folder in node_modules...${NC}"
-rm -rf ./demos/showcase/node_modules/.cache
-rm -rf ./demos/showcase/node_modules/@brightlayer-ui/react-components
-mkdir -p ./demos/showcase/node_modules/@brightlayer-ui/react-components
-rm -rf ./demos/storybook/node_modules/@brightlayer-ui/react-components
-mkdir -p ./demos/storybook/node_modules/@brightlayer-ui/react-components
+rm -rf "./demos/showcase/node_modules/.cache"
+rm -rf "./demos/showcase/node_modules/@brightlayer-ui/react-components"
+mkdir -p "./demos/showcase/node_modules/@brightlayer-ui/react-components"
+# rm -rf ./demos/storybook/node_modules/@brightlayer-ui/react-components
+# mkdir -p ./demos/storybook/node_modules/@brightlayer-ui/react-components
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying build output into node_modules...${NC}";
 cp -r ./components/package.json ./demos/showcase/node_modules/@brightlayer-ui/react-components/package.json
 cp -r ./dist/. ./demos/showcase/node_modules/@brightlayer-ui/react-components
-cp -r ./components/package.json ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json
-cp -r ./dist/. ./demos/storybook/node_modules/@brightlayer-ui/react-components
+# cp -r ./components/package.json ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json
+# cp -r ./dist/. ./demos/storybook/node_modules/@brightlayer-ui/react-components
 echo -e "${GREEN}Done${NC}"
 
 echo -en "\r\n${BLUE}Linking Components: ${NC}"
 if [ ! -f ./demos/showcase/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
-if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
+# if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
 if [ ! -s ./demos/showcase/node_modules/@brightlayer-ui/react-components ];
     then
         if [ ! -f ./demos/showcase/node_modules/@brightlayer-ui/react-components/index.js ];
         then echo -e "${BRED}Not Linked${NC}" && exit 1;
         fi;
 fi
-if [ ! -s ./demos/storybook/node_modules/@brightlayer-ui/react-components ];
-    then
-        if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/index.js ];
-        then echo -e "${BRED}Not Linked${NC}" && exit 1;
-        fi;
-fi
+# if [ ! -s ./demos/storybook/node_modules/@brightlayer-ui/react-components ];
+#     then
+#         if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/index.js ];
+#         then echo -e "${BRED}Not Linked${NC}" && exit 1;
+#         fi;
+# fi
 echo -e "${GRAY}Complete${NC}\r\n"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-3050.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update styles to use Mui-v5 Styled components
- Update component to extend `sx` prop
- Update component docs for `ChannelValue`

Test:
There is a showcase branch `feature/3050-channel-value-mui-v5-styles-update` that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new `sx` prop extension. You can apply styles to the root by using `sx` directly on the component as well as by targeting nested items by the generated classnames. I will work on documentation while this is in draft review.

Here is an example component that you can take parts from to test:

 ```tsx
<ChannelValue
     value={'123'}
     units={'hz'}
     color={'green'}
     classes={{ value: classes.value }}
     sx={{
            mt: 2,
            paddingLeft: '1rem',
            '& .BluiChannelValue-units': { pt: 4, backgroundColor: '#badabd', color: '#bada' },
            '& .BluiChannelValue-value': { pt: 4, backgroundColor: '#c00110', color: '#ee0e' },
      }}
/>
```