### PR TITLE
Feature/3062 spacer react comp mui style engine

### DIFF
--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -1,9 +1,22 @@
-import { CSSProperties } from '@mui/styles';
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
+import { CSSProperties } from '@mui/styles';
+import { Box, BoxProps } from '@mui/material';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { SpacerClasses, getSpacerUtilityClass, SpacerClassKey } from './SpacerClasses';
+import { cx } from '@emotion/css';
+import { styled } from '@mui/material/styles';
 
-export type SpacerProps = HTMLAttributes<HTMLDivElement> & {
+const useUtilityClasses = (ownerState: SpacerProps): Record<SpacerClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+    };
+
+    return composeClasses(slots, getSpacerUtilityClass, classes);
+};
+
+export type SpacerProps = BoxProps & {
     /** Flex grow/shrink value for flex layouts
      *
      * Default: 1
@@ -15,32 +28,39 @@ export type SpacerProps = HTMLAttributes<HTMLDivElement> & {
     width?: number | string;
     /** Custom classes for default style overrides */
     classes?: SpacerClasses;
-    style?: CSSProperties;
+    style?: CSSProperties
 };
-export type SpacerClasses = {
-    root?: string;
-};
+
+const Root = styled(Box, {
+    name: 'spacer',
+    slot: 'root',
+})<Pick<SpacerProps, 'flex' | 'height' | 'width' | 'style'>>(({ flex, height, width, style }) => ({
+    flex: `${flex} ${flex} ${flex === 0 ? 'auto' : '0px'}`,
+    height: height || 'auto',
+    width: width || 'auto',
+    style: style
+}));
 
 const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (props: SpacerProps, ref: any) => {
-    const { children, classes, flex, height, style, width, ...otherDivProps } = props;
+    const { children, classes, flex, height, width, style, ...otherProps } = props;
+    const ownerState = {
+        ...props,
+    };
+    const defaultClasses = useUtilityClasses(ownerState);
 
     return (
-        <div
+        <Root
             ref={ref}
             data-test={'spacer-root'}
-            className={clsx(classes.root)}
-            style={Object.assign(
-                {
-                    flex: `${flex} ${flex} ${flex === 0 ? 'auto' : '0px'}`,
-                    height: height || 'auto',
-                    width: width || 'auto',
-                },
-                { ...style }
-            )}
-            {...otherDivProps}
+            flex={flex}
+            height={height}
+            width={width}
+            className={cx(defaultClasses.root, classes.root)}
+            style={Object.assign({...style})}
+            {...otherProps}
         >
             {children}
-        </div>
+        </Root>
     );
 };
 /**

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CSSProperties } from '@mui/styles';
 import { Box, BoxProps } from '@mui/material';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import { SpacerClasses, getSpacerUtilityClass, SpacerClassKey } from './SpacerClasses';

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -28,21 +28,19 @@ export type SpacerProps = BoxProps & {
     width?: number | string;
     /** Custom classes for default style overrides */
     classes?: SpacerClasses;
-    style?: CSSProperties
 };
 
 const Root = styled(Box, {
     name: 'spacer',
     slot: 'root',
-})<Pick<SpacerProps, 'flex' | 'height' | 'width' | 'style'>>(({ flex, height, width, style }) => ({
+})<Pick<SpacerProps, 'flex' | 'height' | 'width'>>(({ flex, height, width }) => ({
     flex: `${flex} ${flex} ${flex === 0 ? 'auto' : '0px'}`,
     height: height || 'auto',
     width: width || 'auto',
-    style: style
 }));
 
 const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (props: SpacerProps, ref: any) => {
-    const { children, classes, flex, height, width, style, ...otherProps } = props;
+    const { children, classes, flex, height, width, ...otherProps } = props;
     const ownerState = {
         ...props,
     };
@@ -56,7 +54,6 @@ const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (prop
             height={height}
             width={width}
             className={cx(defaultClasses.root, classes.root)}
-            style={Object.assign({...style})}
             {...otherProps}
         >
             {children}

--- a/components/src/core/Utility/SpacerClasses.tsx
+++ b/components/src/core/Utility/SpacerClasses.tsx
@@ -1,0 +1,12 @@
+import { generateUtilityClass } from '@mui/base';
+
+export type SpacerClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+};
+
+export type SpacerClassKey = keyof SpacerClasses;
+
+export function getSpacerUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiSpacer', slot);
+}

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -40,3 +40,19 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | Name | Description                        |
 | ---- | ---------------------------------- |
 | root | Styles applied to the root element |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import * as colors from '@brightlayer-ui/colors';
+import { Spacer } from '@brightlayer-ui/react-components';
+
+<Spacer 
+    width={60} 
+    height={50} 
+    sx={{ background: colors.red[300], display: 'inline-block' }}>
+    {/* Spacer Content */}
+</Spacer>
+```


### PR DESCRIPTION
Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop
Update component docs for Spacer

Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. 