### PR TITLE
Updated EmptyState component to use mui v5 style engine

### DIFF
--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -1,19 +1,26 @@
-import React, { HTMLAttributes, ReactNode } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import { useTheme, Theme } from '@mui/material/styles';
+import React, { ReactNode } from 'react';
+import { styled } from '@mui/material/styles';
+import { cx } from '@emotion/css';
 import Typography from '@mui/material/Typography';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import Box, { BoxProps } from '@mui/material/Box';
+import { EmptyStateClasses, EmptyStateClassKey, getEmptyStateUtilityClass } from './EmptyStateClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-export type EmptyStateClasses = {
-    root?: string;
-    actions?: string;
-    description?: string;
-    icon?: string;
-    title?: string;
+const useUtilityClasses = (ownerState: EmptyStateProps): Record<EmptyStateClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+        actions: ['actions'],
+        description: ['description'],
+        icon: ['icon'],
+        title: ['title'],
+    };
+
+    return composeClasses(slots, getEmptyStateUtilityClass, classes);
 };
 
-export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
+export type EmptyStateProps = BoxProps & {
     /** Additional components to render below */
     actions?: ReactNode;
     /** Custom classes for default style overrides */
@@ -26,55 +33,72 @@ export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
     title: ReactNode;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-    root: {
-        color: theme.palette.text.primary,
-        height: '100%',
-        minHeight: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        flexDirection: 'column',
-        textAlign: 'center',
-        alignItems: 'center',
-        padding: '1rem',
-    },
-    icon: {
-        color: theme.palette.text.secondary,
-        marginBottom: '1rem',
-        display: 'flex',
-        fontSize: 96,
-    },
-    description: {
-        color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.primary,
-    },
-    actions: {
-        marginTop: '1rem',
-    },
+const Root = styled(Box, {
+    name: 'empty-state',
+    slot: 'root',
+})(({ theme }) => ({
+    color: theme.palette.text.primary,
+    height: '100%',
+    minHeight: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    textAlign: 'center',
+    alignItems: 'center',
+    padding: '1rem',
+}));
+
+const Icon = styled(Box, {
+    name: 'empty-state',
+    slot: 'icon',
+})(({ theme }) => ({
+    color: theme.palette.text.secondary,
+    marginBottom: '1rem',
+    display: 'flex',
+    fontSize: 96,
+}));
+
+const Description = styled(Typography, {
+    name: 'empty-state',
+    slot: 'description',
+})(({ theme }) => ({
+    color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.primary,
+}));
+
+const Actions = styled(Box, {
+    name: 'empty-state',
+    slot: 'actions',
+})(() => ({
+    marginTop: '1rem',
 }));
 
 const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps> = (
     props: EmptyStateProps,
     ref: any
 ) => {
-    const { actions, classes, description, icon, title, ...otherDivProps } = props;
-    const defaultClasses = useStyles(useTheme());
+    const { actions, classes, description, icon, title, ...otherProps } = props;
+    const ownerState = {
+        ...props,
+    };
+    const defaultClasses = useUtilityClasses(ownerState);
+
     return (
-        <div ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'frame'} {...otherDivProps}>
-            {icon && <div className={clsx(defaultClasses.icon, classes.icon)}>{icon}</div>}
+        <Root ref={ref} className={cx(defaultClasses.root, classes.root)} data-test={'frame'} {...otherProps}>
+            {icon && <Icon className={cx(defaultClasses.icon, classes.icon)}>{icon}</Icon>}
             <Typography variant="h6" color="inherit" className={classes.title}>
                 {title}
             </Typography>
             {description && (
-                <Typography
+                <Description
                     variant="subtitle2"
                     color={'textSecondary'}
-                    className={clsx(defaultClasses.description, classes.description)}
+                    className={cx(defaultClasses.description, classes.description)}
                 >
                     {description}
-                </Typography>
+                </Description>
             )}
-            {actions && <div className={clsx(defaultClasses.actions, classes.actions)}>{actions}</div>}
-        </div>
+            {actions && <Actions className={cx(defaultClasses.actions, classes.actions)}>{actions}</Actions>}
+        </Root>
     );
 };
 /**

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -72,7 +72,12 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
     const defaultClasses = useUtilityClasses(props);
 
     return (
-        <Root ref={ref} className={cx(defaultClasses.root, classes.root)} data-test={'frame'} {...otherProps}>
+        <Root
+            ref={ref}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
+            data-test={'frame'}
+            {...otherProps}
+        >
             {icon && <div className={cx(defaultClasses.icon, classes.icon)}>{icon}</div>}
             <Typography variant="h6" color="inherit" className={classes.title}>
                 {title}

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -4,7 +4,11 @@ import { cx } from '@emotion/css';
 import Typography from '@mui/material/Typography';
 import PropTypes from 'prop-types';
 import Box, { BoxProps } from '@mui/material/Box';
-import { EmptyStateClasses, EmptyStateClassKey, getEmptyStateUtilityClass } from './EmptyStateClasses';
+import emptyStateClasses, {
+    EmptyStateClasses,
+    EmptyStateClassKey,
+    getEmptyStateUtilityClass,
+} from './EmptyStateClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 
 const useUtilityClasses = (ownerState: EmptyStateProps): Record<EmptyStateClassKey, string> => {
@@ -46,58 +50,43 @@ const Root = styled(Box, {
     textAlign: 'center',
     alignItems: 'center',
     padding: '1rem',
-}));
-
-const Icon = styled(Box, {
-    name: 'empty-state',
-    slot: 'icon',
-})(({ theme }) => ({
-    color: theme.palette.text.secondary,
-    marginBottom: '1rem',
-    display: 'flex',
-    fontSize: 96,
-}));
-
-const Description = styled(Typography, {
-    name: 'empty-state',
-    slot: 'description',
-})(({ theme }) => ({
-    color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.primary,
-}));
-
-const Actions = styled(Box, {
-    name: 'empty-state',
-    slot: 'actions',
-})(() => ({
-    marginTop: '1rem',
+    [`& .${emptyStateClasses.icon}`]: {
+        color: theme.palette.text.secondary,
+        marginBottom: '1rem',
+        display: 'flex',
+        fontSize: 96,
+    },
+    [`& .${emptyStateClasses.description}`]: {
+        color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.primary,
+    },
+    [`& .${emptyStateClasses.actions}`]: {
+        marginTop: '1rem',
+    },
 }));
 
 const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps> = (
     props: EmptyStateProps,
     ref: any
 ) => {
-    const { actions, classes, description, icon, title, ...otherProps } = props;
-    const ownerState = {
-        ...props,
-    };
-    const defaultClasses = useUtilityClasses(ownerState);
+    const { actions, classes, className: userClassName, description, icon, title, ...otherProps } = props;
+    const defaultClasses = useUtilityClasses(props);
 
     return (
         <Root ref={ref} className={cx(defaultClasses.root, classes.root)} data-test={'frame'} {...otherProps}>
-            {icon && <Icon className={cx(defaultClasses.icon, classes.icon)}>{icon}</Icon>}
+            {icon && <div className={cx(defaultClasses.icon, classes.icon)}>{icon}</div>}
             <Typography variant="h6" color="inherit" className={classes.title}>
                 {title}
             </Typography>
             {description && (
-                <Description
+                <Typography
                     variant="subtitle2"
                     color={'textSecondary'}
                     className={cx(defaultClasses.description, classes.description)}
                 >
                     {description}
-                </Description>
+                </Typography>
             )}
-            {actions && <Actions className={cx(defaultClasses.actions, classes.actions)}>{actions}</Actions>}
+            {actions && <div className={cx(defaultClasses.actions, classes.actions)}>{actions}</div>}
         </Root>
     );
 };

--- a/components/src/core/EmptyState/EmptyStateClasses.tsx
+++ b/components/src/core/EmptyState/EmptyStateClasses.tsx
@@ -1,0 +1,15 @@
+import { generateUtilityClass } from '@mui/material';
+
+export type EmptyStateClasses = {
+    root?: string;
+    actions?: string;
+    description?: string;
+    icon?: string;
+    title?: string;
+};
+
+export type EmptyStateClassKey = keyof EmptyStateClasses;
+
+export function getEmptyStateUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiEmptyState', slot);
+}

--- a/components/src/core/EmptyState/EmptyStateClasses.tsx
+++ b/components/src/core/EmptyState/EmptyStateClasses.tsx
@@ -1,4 +1,4 @@
-import { generateUtilityClass } from '@mui/material';
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
 
 export type EmptyStateClasses = {
     root?: string;
@@ -13,3 +13,13 @@ export type EmptyStateClassKey = keyof EmptyStateClasses;
 export function getEmptyStateUtilityClass(slot: string): string {
     return generateUtilityClass('BluiEmptyState', slot);
 }
+
+const emptyStateClasses: EmptyStateClasses = generateUtilityClasses('BluiEmptyState', [
+    'root',
+    'actions',
+    'description',
+    'icon',
+    'title',
+]);
+
+export default emptyStateClasses;

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -45,3 +45,18 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | description | Styles applied to the description  |
 | icon        | Styles applied to the icon         |
 | title       | Styles applied to the title        |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import { EmptyState } from '@brightlayer-ui/react-components';
+import NotListedLocation from '@mui/icons-material/NotListedLocation';
+...
+<EmptyState
+    sx={{margin: '0px'}}
+    icon={<NotListedLocation />}
+    title={'Location Unknown'}
+/>
+```

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -48,11 +48,8 @@ You can override the styles used by Brightlayer UI by passing a `sx` prop. The `
 ```tsx
 import * as colors from '@brightlayer-ui/colors';
 import { Spacer } from '@brightlayer-ui/react-components';
-
-<Spacer 
-    width={60} 
-    height={50} 
-    sx={{ background: colors.red[300], display: 'inline-block' }}>
+...
+<Spacer width={60} height={50} sx={{ background: colors.red[300], display: 'inline-block' }}>
     {/* Spacer Content */}
 </Spacer>
 ```


### PR DESCRIPTION
Fixes BLUI-3053

Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop
Update component docs for EmptyState
Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. 

Here is an example component that you can take parts from to test:
<EmptyState
    sx={{margin: '0px'}}
    icon={<NotListedLocation />}
    title={'Location Unknown'}
/>