### PR TITLE
Feature/3054 update hero comp to use muiv5 style engine

### DIFF
--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -1,12 +1,12 @@
 import React, { ReactNode } from 'react';
 import Typography from '@mui/material/Typography';
 import { ChannelValue, ChannelValueProps as ChannelValuePropsType } from '../ChannelValue';
-import clsx from 'clsx';
+import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
 import Box, { BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { getHeroUtilityClass, HeroClasses, HeroClassKey } from './HeroClasses';
+import heroClasses, { getHeroUtilityClass, HeroClasses, HeroClassKey } from './HeroClasses';
 
 const useUtilityClasses = (ownerState: HeroProps): Record<HeroClassKey, string> => {
     const { classes } = ownerState;
@@ -43,7 +43,9 @@ export type HeroProps = BoxProps & {
     ChannelValueProps?: ChannelValuePropsType;
 };
 
-const Root = styled(Box, { name: 'hero', slot: 'root' })<Pick<HeroProps, 'onClick'>>(({ onClick, theme }) => ({
+const Root = styled(Box, { name: 'hero', slot: 'root' })<
+    Pick<HeroProps, 'onClick' | 'iconSize' | 'iconBackgroundColor'>
+>(({ onClick, iconSize, iconBackgroundColor, theme }) => ({
     fontSize: '1rem',
     display: 'flex',
     flexDirection: 'column',
@@ -54,65 +56,51 @@ const Root = styled(Box, { name: 'hero', slot: 'root' })<Pick<HeroProps, 'onClic
     color: theme.palette.text.primary,
     padding: `1rem ${theme.spacing()}`,
     cursor: onClick ? 'pointer' : 'inherit',
-}));
-
-const Icon = styled(Box, {
-    name: 'hero',
-    slot: 'icon',
-})<Pick<HeroProps, 'iconSize' | 'iconBackgroundColor'>>(({ iconSize, iconBackgroundColor, theme }) => ({
-    lineHeight: 1,
-    color: theme.palette.text.secondary,
-    marginBottom: '.5rem',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    textAlign: 'center',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    padding: `.25rem ${theme.spacing(0.5)}`,
-    borderRadius: '50%',
-    fontSize: typeof iconSize === 'number' ? normalizeIconSize(iconSize) : iconSize,
-    height: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
-    width: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
-    backgroundColor: iconBackgroundColor,
-}));
-
-const ChannelValueContainer = styled(Box, {
-    name: 'hero',
-    slot: 'values',
-})(({ theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    color: theme.palette.text.primary,
-    lineHeight: 1.2,
-    maxWidth: '100%',
-    overflow: 'hidden',
-    fontSize: '1.25rem',
-}));
-
-const Label = styled(Typography, {
-    name: 'hero',
-    slot: 'label',
-})(() => ({
-    fontSize: 'inherit',
-    lineHeight: 1.2,
-    letterSpacing: 0,
-    fontWeight: 600,
-    width: '100%',
-    textAlign: 'center',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
+    [`& .${heroClasses.icon}`]: {
+        lineHeight: 1,
+        color: theme.palette.text.secondary,
+        marginBottom: '.5rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        padding: `.25rem ${theme.spacing(0.5)}`,
+        borderRadius: '50%',
+        fontSize: typeof iconSize === 'number' ? normalizeIconSize(iconSize) : iconSize,
+        height: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
+        width: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
+        backgroundColor: iconBackgroundColor,
+    },
+    [`& .${heroClasses.values}`]: {
+        display: 'flex',
+        alignItems: 'center',
+        color: theme.palette.text.primary,
+        lineHeight: 1.2,
+        maxWidth: '100%',
+        overflow: 'hidden',
+        fontSize: '1.25rem',
+    },
+    [`& .${heroClasses.label}`]: {
+        fontSize: 'inherit',
+        lineHeight: 1.2,
+        letterSpacing: 0,
+        fontWeight: 600,
+        width: '100%',
+        textAlign: 'center',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+    },
 }));
 
 const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: HeroProps, ref: any) => {
-    const ownerState = {
-        ...props,
-    };
-    const defaultClasses = useUtilityClasses(ownerState);
+    const defaultClasses = useUtilityClasses(props);
     const {
         classes,
+        className: userClassName,
         icon,
         label,
         ChannelValueProps,
@@ -125,19 +113,22 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
     } = props;
 
     return (
-        <Root ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'wrapper'} {...otherProps}>
-            <Icon component="span" className={clsx(defaultClasses.icon, classes.icon)}>
-                {icon}
-            </Icon>
-            <ChannelValueContainer component="span" className={clsx(defaultClasses.values, classes.values)}>
+        <Root
+            ref={ref}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
+            data-test={'wrapper'}
+            {...otherProps}
+        >
+            <span className={cx(defaultClasses.icon, classes.icon)}>{icon}</span>
+            <span className={cx(defaultClasses.values, classes.values)}>
                 {!props.children && ChannelValueProps?.value && (
                     <ChannelValue fontSize={ChannelValueProps?.fontSize} {...ChannelValueProps} />
                 )}
                 {props.children}
-            </ChannelValueContainer>
-            <Label variant={'body1'} color={'inherit'} className={clsx(defaultClasses.label, classes.label)}>
+            </span>
+            <Typography variant={'body1'} color={'inherit'} className={cx(defaultClasses.label, classes.label)}>
                 {label}
-            </Label>
+            </Typography>
         </Root>
     );
 };

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -117,6 +117,8 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
             ref={ref}
             className={cx(defaultClasses.root, classes.root, userClassName)}
             data-test={'wrapper'}
+            iconSize={iconSize}
+            iconBackgroundColor={iconBackgroundColor}
             {...otherProps}
         >
             <span className={cx(defaultClasses.icon, classes.icon)}>{icon}</span>

--- a/components/src/core/Hero/Hero.tsx
+++ b/components/src/core/Hero/Hero.tsx
@@ -1,22 +1,28 @@
-import React, { HTMLAttributes, ReactNode } from 'react';
-import { Theme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
+import React, { ReactNode } from 'react';
 import Typography from '@mui/material/Typography';
 import { ChannelValue, ChannelValueProps as ChannelValuePropsType } from '../ChannelValue';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import Box, { BoxProps } from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { getHeroUtilityClass, HeroClasses, HeroClassKey } from './HeroClasses';
+
+const useUtilityClasses = (ownerState: HeroProps): Record<HeroClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+        icon: ['icon'],
+        label: ['label'],
+        values: ['values'],
+    };
+
+    return composeClasses(slots, getHeroUtilityClass, classes);
+};
 
 const normalizeIconSize = (size: number): number => Math.max(10, size);
 
-export type HeroClasses = {
-    root?: string;
-    icon?: string;
-    label?: string;
-    values?: string;
-};
-
-export type HeroProps = HTMLAttributes<HTMLDivElement> & {
+export type HeroProps = BoxProps & {
     /** Custom classes for default style overrides */
     classes?: HeroClasses;
     /** The primary icon */
@@ -37,66 +43,74 @@ export type HeroProps = HTMLAttributes<HTMLDivElement> & {
     ChannelValueProps?: ChannelValuePropsType;
 };
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            fontSize: '1rem',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'flex-start',
-            flex: '1 1 0px',
-            overflow: 'hidden',
-            color: theme.palette.text.primary,
-            padding: `1rem ${theme.spacing()}`,
-            cursor: (props: HeroProps): 'pointer' | 'inherit' => (props.onClick ? 'pointer' : 'inherit'),
-        },
-        icon: {
-            lineHeight: 1,
-            color: theme.palette.text.secondary,
-            marginBottom: '.5rem',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            textAlign: 'center',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-            padding: `.25rem ${theme.spacing(0.5)}`,
-            borderRadius: '50%',
-            fontSize: (props: HeroProps): number | string =>
-                typeof props.iconSize === 'number' ? normalizeIconSize(props.iconSize) : props.iconSize,
-            height: (props: HeroProps): number | string =>
-                typeof props.iconSize === 'number' ? Math.max(44, props.iconSize) : props.iconSize,
-            width: (props: HeroProps): number | string =>
-                typeof props.iconSize === 'number' ? Math.max(44, props.iconSize) : props.iconSize,
-            backgroundColor: (props: HeroProps): string => props.iconBackgroundColor,
-        },
-        values: {
-            display: 'flex',
-            alignItems: 'center',
-            color: theme.palette.text.primary,
-            lineHeight: 1.2,
-            maxWidth: '100%',
-            overflow: 'hidden',
-            fontSize: '1.25rem',
-        },
-        label: {
-            fontSize: 'inherit',
-            lineHeight: 1.2,
-            letterSpacing: 0,
-            fontWeight: 600,
-            width: '100%',
-            textAlign: 'center',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
-        },
-    })
-);
+const Root = styled(Box, { name: 'hero', slot: 'root' })<Pick<HeroProps, 'onClick'>>(({ onClick, theme }) => ({
+    fontSize: '1rem',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    flex: '1 1 0px',
+    overflow: 'hidden',
+    color: theme.palette.text.primary,
+    padding: `1rem ${theme.spacing()}`,
+    cursor: onClick ? 'pointer' : 'inherit',
+}));
+
+const Icon = styled(Box, {
+    name: 'hero',
+    slot: 'icon',
+})<Pick<HeroProps, 'iconSize' | 'iconBackgroundColor'>>(({ iconSize, iconBackgroundColor, theme }) => ({
+    lineHeight: 1,
+    color: theme.palette.text.secondary,
+    marginBottom: '.5rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    padding: `.25rem ${theme.spacing(0.5)}`,
+    borderRadius: '50%',
+    fontSize: typeof iconSize === 'number' ? normalizeIconSize(iconSize) : iconSize,
+    height: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
+    width: typeof iconSize === 'number' ? Math.max(44, iconSize) : iconSize,
+    backgroundColor: iconBackgroundColor,
+}));
+
+const ChannelValueContainer = styled(Box, {
+    name: 'hero',
+    slot: 'values',
+})(({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    color: theme.palette.text.primary,
+    lineHeight: 1.2,
+    maxWidth: '100%',
+    overflow: 'hidden',
+    fontSize: '1.25rem',
+}));
+
+const Label = styled(Typography, {
+    name: 'hero',
+    slot: 'label',
+})(() => ({
+    fontSize: 'inherit',
+    lineHeight: 1.2,
+    letterSpacing: 0,
+    fontWeight: 600,
+    width: '100%',
+    textAlign: 'center',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+}));
 
 const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: HeroProps, ref: any) => {
-    const defaultClasses = useStyles(props);
+    const ownerState = {
+        ...props,
+    };
+    const defaultClasses = useUtilityClasses(ownerState);
     const {
         classes,
         icon,
@@ -107,22 +121,24 @@ const HeroRender: React.ForwardRefRenderFunction<unknown, HeroProps> = (props: H
         iconBackgroundColor,
         iconSize,
         /* eslint-enable @typescript-eslint/no-unused-vars */
-        ...otherDivProps
+        ...otherProps
     } = props;
 
     return (
-        <div ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'wrapper'} {...otherDivProps}>
-            <span className={clsx(defaultClasses.icon, classes.icon)}>{icon}</span>
-            <span className={clsx(defaultClasses.values, classes.values)}>
+        <Root ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'wrapper'} {...otherProps}>
+            <Icon component="span" className={clsx(defaultClasses.icon, classes.icon)}>
+                {icon}
+            </Icon>
+            <ChannelValueContainer component="span" className={clsx(defaultClasses.values, classes.values)}>
                 {!props.children && ChannelValueProps?.value && (
                     <ChannelValue fontSize={ChannelValueProps?.fontSize} {...ChannelValueProps} />
                 )}
                 {props.children}
-            </span>
-            <Typography variant={'body1'} color={'inherit'} className={clsx(defaultClasses.label, classes.label)}>
+            </ChannelValueContainer>
+            <Label variant={'body1'} color={'inherit'} className={clsx(defaultClasses.label, classes.label)}>
                 {label}
-            </Typography>
-        </div>
+            </Label>
+        </Root>
     );
 };
 /**

--- a/components/src/core/Hero/HeroClasses.tsx
+++ b/components/src/core/Hero/HeroClasses.tsx
@@ -1,4 +1,4 @@
-import { generateUtilityClass } from '@mui/material';
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
 
 export type HeroClasses = {
     root?: string;
@@ -12,3 +12,7 @@ export type HeroClassKey = keyof HeroClasses;
 export function getHeroUtilityClass(slot: string): string {
     return generateUtilityClass('BluiHero', slot);
 }
+
+const heroClasses: HeroClasses = generateUtilityClasses('BluiHero', ['root', 'icon', 'label', 'values']);
+
+export default heroClasses;

--- a/components/src/core/Hero/HeroClasses.tsx
+++ b/components/src/core/Hero/HeroClasses.tsx
@@ -1,0 +1,14 @@
+import { generateUtilityClass } from '@mui/material';
+
+export type HeroClasses = {
+    root?: string;
+    icon?: string;
+    label?: string;
+    values?: string;
+};
+
+export type HeroClassKey = keyof HeroClasses;
+
+export function getHeroUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiHero', slot);
+}

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -102,3 +102,14 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | Name | Description                        |
 | ---- | ---------------------------------- |
 | root | Styles applied to the root element |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import * as colors from '@brightlayer-ui/colors';
+import { Hero } from '@brightlayer-ui/react-components';
+
+<Hero sx={{ margin: '1rem' }} icon={<GradeA fontSize={'inherit'} />} label={'Efficiency'} />
+```

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -112,6 +112,7 @@ You can override the styles used by Brightlayer UI by passing a `sx` prop. The `
 
 ```tsx
 import { Hero } from '@brightlayer-ui/react-components';
+import GradeA from '@brightlayer-ui/icons-mui/GradeA';
 
 <Hero sx={{ margin: '1rem' }} icon={<GradeA fontSize={'inherit'} />} label={'Efficiency'} />;
 ```

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -99,12 +99,12 @@ Any other props supplied will be provided to the root element (`div`).
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. It supports the following keys:
 
-| Name   | Description                          |
-| ------ | ------------------------------------ |
-| root   | Styles applied to the root element   |
-| icon   | Styles applied to the icon element   |
-| label  | Styles applied to the label element  |
-| values | Styles applied to the values element |
+| Name   | Description                        |
+| ------ | ---------------------------------- |
+| root   | Styles applied to the root element |
+| icon   | Styles applied to the icon         |
+| label  | Styles applied to the label        |
+| values | Styles applied to the values       |
 
 ### `sx` Class Overrides
 

--- a/docs/Hero.md
+++ b/docs/Hero.md
@@ -99,17 +99,19 @@ Any other props supplied will be provided to the root element (`div`).
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. It supports the following keys:
 
-| Name | Description                        |
-| ---- | ---------------------------------- |
-| root | Styles applied to the root element |
+| Name   | Description                          |
+| ------ | ------------------------------------ |
+| root   | Styles applied to the root element   |
+| icon   | Styles applied to the icon element   |
+| label  | Styles applied to the label element  |
+| values | Styles applied to the values element |
 
 ### `sx` Class Overrides
 
 You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
 
 ```tsx
-import * as colors from '@brightlayer-ui/colors';
 import { Hero } from '@brightlayer-ui/react-components';
 
-<Hero sx={{ margin: '1rem' }} icon={<GradeA fontSize={'inherit'} />} label={'Efficiency'} />
+<Hero sx={{ margin: '1rem' }} icon={<GradeA fontSize={'inherit'} />} label={'Efficiency'} />;
 ```


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3054

Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop
Update component docs for Hero
Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames.

Here is an example component that you can take parts from to test:
<Hero sx={{ margin: '1rem' }} icon={<GradeA fontSize={'inherit'} />} label={'Efficiency'} style={{ flex: 1 }} />
