### PR TITLE
use styled engine for ThreeLiner component

### DIFF
--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -96,7 +96,7 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
     const defaultClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
-        <Root ref={ref} {...otherProps} className={cx(defaultClasses.root, classes.root, userClassName)}>
+        <Root ref={ref} {...otherProps} animationDuration={animationDuration} className={cx(defaultClasses.root, classes.root, userClassName)}>
             <div className={cx(defaultClasses.title, classes.title)}>{title}</div>
             <div className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
             <div className={cx(defaultClasses.info, classes.info)}>{info}</div>

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -96,7 +96,12 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
     const defaultClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
-        <Root ref={ref} {...otherProps} animationDuration={animationDuration} className={cx(defaultClasses.root, classes.root, userClassName)}>
+        <Root
+            ref={ref}
+            {...otherProps}
+            animationDuration={animationDuration}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
+        >
             <div className={cx(defaultClasses.title, classes.title)}>{title}</div>
             <div className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
             <div className={cx(defaultClasses.info, classes.info)}>{info}</div>

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -1,58 +1,28 @@
-import React, { HTMLAttributes, ReactNode } from 'react';
-import { Theme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from 'clsx';
+import React, { ReactNode } from 'react';
+import { cx } from '@emotion/css';
+import { Box, BoxProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import threeLinerClasses, {
+    ThreeLinerClasses,
+    ThreeLinerClassKey,
+    getThreeLinerUtilityClass,
+} from './ThreeLinerClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-export type ThreeLinerClasses = {
-    root?: string;
-    title?: string;
-    subtitle?: string;
-    info?: string;
+const useUtilityClasses = (ownerState: ThreeLinerProps): Record<ThreeLinerClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        title: ['title'],
+        subtitle: ['subtitle'],
+        info: ['info'],
+    };
+
+    return composeClasses(slots, getThreeLinerUtilityClass, classes);
 };
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            display: 'flex',
-            height: '100%',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        title: {
-            fontSize: '1.875rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        subtitle: {
-            fontSize: '1rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        info: {
-            fontSize: '0.875rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-            fontWeight: 300,
-        },
-    })
-);
-
-export type ThreeLinerProps = HTMLAttributes<HTMLDivElement> & {
+export type ThreeLinerProps = BoxProps & {
     /** First Line Content */
     title?: ReactNode;
 
@@ -72,6 +42,42 @@ export type ThreeLinerProps = HTMLAttributes<HTMLDivElement> & {
     classes?: Partial<ThreeLinerClasses>;
 };
 
+const Root = styled(Box, {
+    name: 'three-liner',
+    slot: 'root',
+})<Pick<ThreeLinerProps, 'animationDuration'>>(({ animationDuration, theme }) => ({
+    display: 'flex',
+    height: '100%',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    transition: theme.transitions.create(['all'], {
+        duration: animationDuration || theme.transitions.duration.standard,
+        easing: theme.transitions.easing.easeInOut,
+    }),
+    [`& .${threeLinerClasses.title}`]: {
+        fontSize: '1.875rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+    },
+    [`& .${threeLinerClasses.subtitle}`]: {
+        fontSize: '1rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+    },
+    [`& .${threeLinerClasses.info}`]: {
+        fontSize: '0.875rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+        fontWeight: 300,
+    },
+}));
+
 const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProps> = (
     props: ThreeLinerProps,
     ref: any
@@ -81,20 +87,19 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         subtitle,
         info,
         classes = {},
-        className,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
         animationDuration,
-        ...otherDivProps
+        ...otherProps
     } = props;
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
-        <div ref={ref} {...otherDivProps} className={clsx(defaultClasses.root, classes.root, className)}>
-            <div className={clsx(defaultClasses.title, classes.title)}>{title}</div>
-            <div className={clsx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
-            <div className={clsx(defaultClasses.info, classes.info)}>{info}</div>
-        </div>
+        <Root ref={ref} {...otherProps} className={cx(defaultClasses.root, classes.root)}>
+            <div className={cx(defaultClasses.title, classes.title)}>{title}</div>
+            <div className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
+            <div className={cx(defaultClasses.info, classes.info)}>{info}</div>
+        </Root>
     );
 };
 /**

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -87,6 +87,7 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         subtitle,
         info,
         classes = {},
+        className: userClassName,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
         animationDuration,
@@ -95,7 +96,7 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
     const defaultClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
-        <Root ref={ref} {...otherProps} className={cx(defaultClasses.root, classes.root)}>
+        <Root ref={ref} {...otherProps} className={cx(defaultClasses.root, classes.root, userClassName)}>
             <div className={cx(defaultClasses.title, classes.title)}>{title}</div>
             <div className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
             <div className={cx(defaultClasses.info, classes.info)}>{info}</div>

--- a/components/src/core/ThreeLiner/ThreeLinerClasses.tsx
+++ b/components/src/core/ThreeLiner/ThreeLinerClasses.tsx
@@ -1,0 +1,29 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export type ThreeLinerClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+    /** First Line Content */
+    title?: string;
+
+    /** Second Line Content */
+    subtitle?: string;
+
+    /** Third Line Content */
+    info?: string;
+};
+
+export type ThreeLinerClassKey = keyof ThreeLinerClasses;
+
+export function getThreeLinerUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiThreeLiner', slot);
+}
+
+const threeLinerClasses: ThreeLinerClasses = generateUtilityClasses('BluiThreeLiner', [
+    'root',
+    'title',
+    'subtitle',
+    'info',
+]);
+
+export default threeLinerClasses;

--- a/docs/ThreeLiner.md
+++ b/docs/ThreeLiner.md
@@ -25,3 +25,19 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | title    | Styles applied to the first line   |
 | subtitle | Styles applied to the second line  |
 | info     | Styles applied to the third line   |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import { ThreeLiner } from '@brightlayer-ui/react-components';
+import * as colors from '@brightlayer-ui/colors';
+...
+<ThreeLiner
+    sx={{ color: colors.blue[200] }}
+    title={'Three Liner Component'}
+    subtitle={'with basic usage'}
+    info={'...and a third line'}
+/>
+```


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes 3059 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update ThreeLiner component with styled
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1787" alt="Screenshot 2022-04-21 at 7 13 40 PM" src="https://user-images.githubusercontent.com/10433274/164471265-6d197b7b-7334-41b3-8a59-8eea26f835a5.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Use react-showcase-demo branch  `feature/3050-channel-value-mui-v5-styles-update`. Use following snippet code.

`
       <ThreeLiner
                sx={{ color: colors.blue[200], marginTop: theme.spacing(4) }}
                title={'Three Liner Component'}
                subtitle={'with custom content'}
                info={
                    <ChannelValue
                        value={'123'}
                        units={'hz'}
                        icon={<TrendingUp htmlColor={colors.red[500]} className={clsx({ [classes.iconFlip]: rtl })} />}
                    />
                }
            />
`
Test URL:
- /brightlayer-ui-components/data-display-components
- /brightlayer-ui-components/surface-components