### PR TITLE
Feature/3055 hero banner use mui v5 style engine

### DIFF
--- a/components/src/core/HeroBanner/HeroBanner.tsx
+++ b/components/src/core/HeroBanner/HeroBanner.tsx
@@ -1,22 +1,23 @@
-import React, { HTMLAttributes } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
+import React from 'react';
 import Divider from '@mui/material/Divider';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import { cx } from '@emotion/css';
+import { getHeroBannerUtilityClass, HeroBannerClasses, HeroBannerClassKey } from './HeroBannerClasses';
+import { Box, BoxProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-const useStyles = makeStyles({
-    root: {
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-    },
-});
+const useUtilityClasses = (ownerState: HeroBannerProps): Record<HeroBannerClassKey, string> => {
+    const { classes } = ownerState;
 
-export type HeroBannerClasses = {
-    root?: string;
+    const slots = {
+        root: ['root'],
+    };
+
+    return composeClasses(slots, getHeroBannerUtilityClass, classes);
 };
 
-export type HeroBannerProps = HTMLAttributes<HTMLDivElement> & {
+export type HeroBannerProps = BoxProps & {
     /** Custom classes for default style overrides */
     classes?: HeroBannerClasses;
     /** Whether to show the line separator */
@@ -25,21 +26,30 @@ export type HeroBannerProps = HTMLAttributes<HTMLDivElement> & {
     limit?: number;
 };
 
+const Root = styled(Box, {
+    name: 'hero-banner',
+    slot: 'root',
+})(() => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+}));
+
 const HeroBannerRender: React.ForwardRefRenderFunction<unknown, HeroBannerProps> = (
     props: HeroBannerProps,
     ref: any
 ) => {
-    const { classes, divider, limit, ...otherDivProps } = props;
-    const defaultClasses = useStyles(props);
+    const { classes, className: userClassName, divider, limit, ...otherProps } = props;
+    const defaultClasses = useUtilityClasses(props);
     const isArray = Array.isArray(props.children);
     return (
         <>
-            <div ref={ref} className={clsx(defaultClasses.root, classes.root)} {...otherDivProps}>
+            <Root ref={ref} className={cx(defaultClasses.root, classes.root, userClassName)} {...otherProps}>
                 {props.children &&
                     isArray &&
-                    (props.children as React.ReactNodeArray).slice(0, limit).map((child: any) => child)}
+                    (props.children as React.ReactNode[]).slice(0, limit).map((child: any) => child)}
                 {props.children && !isArray && <>{props.children}</>}
-            </div>
+            </Root>
             {divider && <Divider />}
         </>
     );

--- a/components/src/core/HeroBanner/HeroBannerClasses.tsx
+++ b/components/src/core/HeroBanner/HeroBannerClasses.tsx
@@ -1,0 +1,11 @@
+import { generateUtilityClass } from '@mui/material';
+
+export type HeroBannerClasses = {
+    root?: string;
+};
+
+export type HeroBannerClassKey = keyof HeroBannerClasses;
+
+export function getHeroBannerUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiHeroBanner', slot);
+}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3055

Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop

Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. I will work on documentation while this is in draft review.
