### PR TITLE
Feature/3056 update infolistitem to use style engine

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -14,6 +14,7 @@
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
         "@brightlayer-ui/colors": "^3.0.0",
+        "@emotion/css": "^11.9.0",
         "@seznam/compose-react-refs": "^1.0.6",
         "color": "^4.2.1"
     },

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -1,17 +1,33 @@
-import React, { useCallback, HTMLAttributes } from 'react';
+import React, { useCallback } from 'react';
 import Typography from '@mui/material/Typography';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
-import clsx from 'clsx';
+import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
+import { Box, BoxProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import channelValueClasses, {
+    ChannelValueClasses,
+    ChannelValueClassKey,
+    getChannelValueUtilityClass,
+} from './ChannelValueClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-export type ChannelValueClasses = {
-    root?: string;
-    icon?: string;
-    units?: string;
-    value?: string;
+const useUtilityClasses = (ownerState: ChannelValueProps): Record<ChannelValueClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        icon: ['icon'],
+        text: ['text'],
+        prefix: ['prefix'],
+        suffix: ['suffix'],
+        value: ['value'],
+        units: ['units'],
+    };
+
+    return composeClasses(slots, getChannelValueUtilityClass, classes);
 };
-export type ChannelValueProps = Omit<HTMLAttributes<HTMLSpanElement>, 'prefix'> & {
+
+export type ChannelValueProps = Omit<BoxProps, 'prefix'> & {
     /** Custom classes for default style overrides */
     classes?: ChannelValueClasses;
     /** The color used for the text elements
@@ -45,42 +61,37 @@ export type ChannelValueProps = Omit<HTMLAttributes<HTMLSpanElement>, 'prefix'> 
     value: number | string;
 };
 
-const useStyles = makeStyles(() =>
-    createStyles({
-        root: {
-            display: 'inline-flex',
-            alignItems: 'center',
-            lineHeight: 1.2,
-            fontSize: (props: ChannelValueProps): string | number => props.fontSize,
-            color: (props: ChannelValueProps): string => props.color,
+const Root = styled(Box, {
+    name: 'channel-value',
+    slot: 'root',
+})<Pick<ChannelValueProps, 'fontSize' | 'color'>>(({ fontSize, color }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    lineHeight: 1.2,
+    fontSize: fontSize,
+    color: color,
+    [`& .${channelValueClasses.icon}`]: {
+        marginRight: '0.35em',
+        display: 'inline',
+        fontSize: 'inherit',
+    },
+    [`& .${channelValueClasses.text}`]: { fontSize: 'inherit', lineHeight: 'inherit', letterSpacing: 0 },
+    [`& .${channelValueClasses.suffix}`]: {},
+    [`& .${channelValueClasses.prefix}`]: {
+        '& + h6': {
+            marginLeft: '0.25em',
         },
-        icon: {
-            marginRight: '0.35em',
-            display: 'inline',
-            fontSize: 'inherit',
+    },
+    [`& .${channelValueClasses.value}`]: {
+        fontWeight: 600,
+        '& + $suffix': {
+            marginLeft: '0.25em',
         },
-        text: {
-            fontSize: 'inherit',
-            lineHeight: 'inherit',
-            letterSpacing: 0,
-        },
-        prefix: {
-            '& + h6': {
-                marginLeft: '0.25em',
-            },
-        },
-        suffix: {},
-        units: {
-            fontWeight: 300,
-        },
-        value: {
-            fontWeight: 600,
-            '& + $suffix': {
-                marginLeft: '0.25em',
-            },
-        },
-    })
-);
+    },
+    [`& .${channelValueClasses.units}`]: {
+        fontWeight: 300,
+    },
+}));
 
 const changeIconDisplay = (newIcon: JSX.Element): JSX.Element =>
     React.cloneElement(newIcon, {
@@ -103,9 +114,9 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         color,
         fontSize,
         /* eslint-enable @typescript-eslint/no-unused-vars */
-        ...otherSpanProps
+        ...otherProps
     } = props;
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     const prefixUnitAllowSpaceList = ['$'];
     const suffixUnitAllowSpaceList = ['%', '℉', '°F', '℃', '°C', '°'];
 
@@ -128,10 +139,20 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                     <Typography
                         variant={'h6'}
                         color={'inherit'}
-                        className={clsx(defaultClasses.text, defaultClasses.units, classes.units, {
-                            [defaultClasses.prefix]: applyPrefix(),
-                            [defaultClasses.suffix]: applySuffix(),
-                        })}
+                        className={cx(
+                            defaultClasses.text,
+                            classes.text,
+                            defaultClasses.units,
+                            classes.units,
+                            {
+                                [defaultClasses.prefix]: applyPrefix(),
+                                [defaultClasses.suffix]: applySuffix(),
+                            },
+                            {
+                                [classes.prefix]: applyPrefix(),
+                                [classes.suffix]: applySuffix(),
+                            }
+                        )}
                         data-test={'units'}
                     >
                         {units}
@@ -143,9 +164,17 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
     );
 
     return (
-        <span ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'wrapper'} {...otherSpanProps}>
+        <Root
+            component="span"
+            ref={ref}
+            className={cx(defaultClasses.root, classes.root)}
+            data-test={'wrapper'}
+            fontSize={fontSize}
+            color={color}
+            {...otherProps}
+        >
             {icon && (
-                <span className={clsx(defaultClasses.icon, classes.icon)} data-test={'icon'}>
+                <span className={cx(defaultClasses.icon, classes.icon)} data-test={'icon'}>
                     {changeIconDisplay(icon)}
                 </span>
             )}
@@ -153,13 +182,13 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
             <Typography
                 variant={'h6'}
                 color={'inherit'}
-                className={clsx(defaultClasses.text, defaultClasses.value, classes.value)}
+                className={cx(defaultClasses.text, classes.text, defaultClasses.value, classes.value)}
                 data-test={'value'}
             >
                 {value}
             </Typography>
             {!prefix && getUnitElement()}
-        </span>
+        </Root>
     );
 };
 /**
@@ -175,6 +204,9 @@ ChannelValue.propTypes = {
     classes: PropTypes.shape({
         root: PropTypes.string,
         icon: PropTypes.string,
+        text: PropTypes.string,
+        prefix: PropTypes.string,
+        suffix: PropTypes.string,
         value: PropTypes.string,
         units: PropTypes.string,
     }),

--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -104,6 +104,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
 ) => {
     const {
         classes,
+        className: userClassName,
         icon,
         prefix,
         units,
@@ -167,7 +168,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         <Root
             component="span"
             ref={ref}
-            className={cx(defaultClasses.root, classes.root)}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
             data-test={'wrapper'}
             fontSize={fontSize}
             color={color}

--- a/components/src/core/ChannelValue/ChannelValueClasses.tsx
+++ b/components/src/core/ChannelValue/ChannelValueClasses.tsx
@@ -1,0 +1,36 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export type ChannelValueClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+    /** Styles applied to the icon element. */
+    icon?: string;
+    /** Styles applied to the text element. */
+    text?: string;
+    /** Styles applied to the prefix element. */
+    prefix?: string;
+    /** Styles applied to the suffix element. */
+    suffix?: string;
+    /** Styles applied to the units element. */
+    units?: string;
+    /** Styles applied to the value element. */
+    value?: string;
+};
+
+export type ChannelValueClassKey = keyof ChannelValueClasses;
+
+export function getChannelValueUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiChannelValue', slot);
+}
+
+const channelValueClasses: ChannelValueClasses = generateUtilityClasses('BluiChannelValue', [
+    'root',
+    'icon',
+    'text',
+    'prefix',
+    'suffix',
+    'units',
+    'value',
+]);
+
+export default channelValueClasses;

--- a/components/src/core/EmptyState/EmptyState.tsx
+++ b/components/src/core/EmptyState/EmptyState.tsx
@@ -1,19 +1,30 @@
-import React, { HTMLAttributes, ReactNode } from 'react';
-import makeStyles from '@mui/styles/makeStyles';
-import { useTheme, Theme } from '@mui/material/styles';
+import React, { ReactNode } from 'react';
+import { styled } from '@mui/material/styles';
+import { cx } from '@emotion/css';
 import Typography from '@mui/material/Typography';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
+import Box, { BoxProps } from '@mui/material/Box';
+import emptyStateClasses, {
+    EmptyStateClasses,
+    EmptyStateClassKey,
+    getEmptyStateUtilityClass,
+} from './EmptyStateClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-export type EmptyStateClasses = {
-    root?: string;
-    actions?: string;
-    description?: string;
-    icon?: string;
-    title?: string;
+const useUtilityClasses = (ownerState: EmptyStateProps): Record<EmptyStateClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+        actions: ['actions'],
+        description: ['description'],
+        icon: ['icon'],
+        title: ['title'],
+    };
+
+    return composeClasses(slots, getEmptyStateUtilityClass, classes);
 };
 
-export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
+export type EmptyStateProps = BoxProps & {
     /** Additional components to render below */
     actions?: ReactNode;
     /** Custom classes for default style overrides */
@@ -26,28 +37,29 @@ export type EmptyStateProps = HTMLAttributes<HTMLDivElement> & {
     title: ReactNode;
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-    root: {
-        color: theme.palette.text.primary,
-        height: '100%',
-        minHeight: '100%',
-        display: 'flex',
-        justifyContent: 'center',
-        flexDirection: 'column',
-        textAlign: 'center',
-        alignItems: 'center',
-        padding: '1rem',
-    },
-    icon: {
+const Root = styled(Box, {
+    name: 'empty-state',
+    slot: 'root',
+})(({ theme }) => ({
+    color: theme.palette.text.primary,
+    height: '100%',
+    minHeight: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    textAlign: 'center',
+    alignItems: 'center',
+    padding: '1rem',
+    [`& .${emptyStateClasses.icon}`]: {
         color: theme.palette.text.secondary,
         marginBottom: '1rem',
         display: 'flex',
         fontSize: 96,
     },
-    description: {
+    [`& .${emptyStateClasses.description}`]: {
         color: theme.palette.mode === 'dark' ? theme.palette.text.secondary : theme.palette.text.primary,
     },
-    actions: {
+    [`& .${emptyStateClasses.actions}`]: {
         marginTop: '1rem',
     },
 }));
@@ -56,11 +68,17 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
     props: EmptyStateProps,
     ref: any
 ) => {
-    const { actions, classes, description, icon, title, ...otherDivProps } = props;
-    const defaultClasses = useStyles(useTheme());
+    const { actions, classes, className: userClassName, description, icon, title, ...otherProps } = props;
+    const defaultClasses = useUtilityClasses(props);
+
     return (
-        <div ref={ref} className={clsx(defaultClasses.root, classes.root)} data-test={'frame'} {...otherDivProps}>
-            {icon && <div className={clsx(defaultClasses.icon, classes.icon)}>{icon}</div>}
+        <Root
+            ref={ref}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
+            data-test={'frame'}
+            {...otherProps}
+        >
+            {icon && <div className={cx(defaultClasses.icon, classes.icon)}>{icon}</div>}
             <Typography variant="h6" color="inherit" className={classes.title}>
                 {title}
             </Typography>
@@ -68,13 +86,13 @@ const EmptyStateRender: React.ForwardRefRenderFunction<unknown, EmptyStateProps>
                 <Typography
                     variant="subtitle2"
                     color={'textSecondary'}
-                    className={clsx(defaultClasses.description, classes.description)}
+                    className={cx(defaultClasses.description, classes.description)}
                 >
                     {description}
                 </Typography>
             )}
-            {actions && <div className={clsx(defaultClasses.actions, classes.actions)}>{actions}</div>}
-        </div>
+            {actions && <div className={cx(defaultClasses.actions, classes.actions)}>{actions}</div>}
+        </Root>
     );
 };
 /**

--- a/components/src/core/EmptyState/EmptyStateClasses.tsx
+++ b/components/src/core/EmptyState/EmptyStateClasses.tsx
@@ -1,0 +1,25 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
+
+export type EmptyStateClasses = {
+    root?: string;
+    actions?: string;
+    description?: string;
+    icon?: string;
+    title?: string;
+};
+
+export type EmptyStateClassKey = keyof EmptyStateClasses;
+
+export function getEmptyStateUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiEmptyState', slot);
+}
+
+const emptyStateClasses: EmptyStateClasses = generateUtilityClasses('BluiEmptyState', [
+    'root',
+    'actions',
+    'description',
+    'icon',
+    'title',
+]);
+
+export default emptyStateClasses;

--- a/components/src/core/ListItemTag/ListItemTag.tsx
+++ b/components/src/core/ListItemTag/ListItemTag.tsx
@@ -1,10 +1,21 @@
 import Typography, { TypographyProps } from '@mui/material/Typography';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
-import { Theme } from '@mui/material/styles';
+import { styled } from '@mui/material/styles';
 import React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import listItemTagClasses, { ListItemTagClassKey, getListItemTagUtilityClass } from './ListItemTagClasses';
+import { cx } from '@emotion/css';
+
+const useUtilityClasses = (ownerState: ListItemTagProps): Record<ListItemTagClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        noVariant: ['noVariant'],
+    };
+
+    return composeClasses(slots, getListItemTagUtilityClass, classes);
+};
 
 export type ListItemTagProps = TypographyProps & {
     /** Color of the label background
@@ -35,28 +46,30 @@ declare module '@mui/styles/withStyles' {
     }
 }
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            flip: false, // letter-spacing doesn't flip for RTL, so neither shall our padding hack to offset it
-            borderRadius: '0.125rem',
-            padding: 0,
-            paddingLeft: theme.spacing(0.5),
-            paddingRight: `calc(${theme.spacing(0.5)} - 1px)`, // to account for extra pixel from letter-spacing
-            overflow: 'hidden',
-            backgroundColor: (props: ListItemTagProps): string =>
-                props.backgroundColor ||
-                (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main),
-            color: (props: ListItemTagProps): string =>
-                props.fontColor ||
-                theme.palette.getContrastText(
-                    props.backgroundColor ||
-                        (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main)
-                ),
-            cursor: (props: ListItemTagProps): string => (props.onClick ? 'pointer' : 'inherit'),
-            display: 'inline-block',
-        },
-        noVariant: {
+const Root = styled(Typography, {
+    name: 'list-item-tag',
+    slot: 'root',
+    shouldForwardProp: (prop) => prop !== 'fontColor',
+})<Pick<ListItemTagProps, 'backgroundColor' | 'fontColor' | 'onClick' | 'variant'>>(
+    ({ backgroundColor, fontColor, onClick, theme }) => ({
+        flip: false, // letter-spacing doesn't flip for RTL, so neither shall our padding hack to offset it
+        borderRadius: '0.125rem',
+        padding: 0,
+        paddingLeft: '0.5rem',
+        paddingRight: `calc(0.5rem - 1px)`, // to account for extra pixel from letter-spacing
+        overflow: 'hidden',
+        display: 'inline-block',
+        cursor: onClick ? 'pointer' : 'inherit',
+        backgroundColor:
+            backgroundColor ||
+            (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main),
+        color:
+            fontColor ||
+            theme.palette.getContrastText(
+                backgroundColor ||
+                    (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main)
+            ),
+        [`&.${listItemTagClasses.noVariant}`]: {
             fontWeight: 700, // bold
             letterSpacing: 1,
             fontSize: `0.625rem`,
@@ -70,32 +83,20 @@ const ListItemTagRender: React.ForwardRefRenderFunction<unknown, ListItemTagProp
     props: ListItemTagProps,
     ref: any
 ) => {
-    const {
-        classes: userClasses,
-        label,
-        variant,
-        // ignore unused vars so that we can do prop transferring to the root element
-        /* eslint-disable @typescript-eslint/no-unused-vars */
-        fontColor,
-        backgroundColor,
-        /* eslint-enable @typescript-eslint/no-unused-vars */
-        ...otherTypographyProps
-    } = props;
-    const defaultClasses = useStyles(props);
+    const { classes: userClasses, label, variant, className: userClassName, ...otherTypographyProps } = props;
+    const defaultClasses = useUtilityClasses(props);
     const { root: rootUserClass, ...otherUserClasses } = userClasses;
     return (
-        <Typography
+        <Root
             ref={ref}
-            classes={{
-                root: clsx(defaultClasses.root, rootUserClass, { [defaultClasses.noVariant]: !variant }),
-                ...otherUserClasses,
-            }}
             variant={variant || 'overline'}
+            className={cx(defaultClasses.root, { [defaultClasses.noVariant]: !variant }, userClassName)}
+            classes={{ root: rootUserClass, ...otherUserClasses }}
             data-test={'list-item-tag'}
             {...otherTypographyProps}
         >
             {label}
-        </Typography>
+        </Root>
     );
 };
 /**
@@ -109,6 +110,9 @@ ListItemTag.propTypes = {
     label: PropTypes.string.isRequired,
     backgroundColor: PropTypes.string,
     fontColor: PropTypes.string,
+    classes: PropTypes.shape({
+        root: PropTypes.string,
+    }),
 };
 ListItemTag.defaultProps = {
     noWrap: true,

--- a/components/src/core/ListItemTag/ListItemTagClasses.tsx
+++ b/components/src/core/ListItemTag/ListItemTagClasses.tsx
@@ -1,0 +1,18 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export type ListItemTagClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+    /** Styles applied to the root element if there is no variant. */
+    noVariant?: string;
+};
+
+export type ListItemTagClassKey = keyof ListItemTagClasses;
+
+export function getListItemTagUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiListItemTag', slot);
+}
+
+const listItemTagClasses: ListItemTagClasses = generateUtilityClasses('BluiListItemTag', ['root', 'noVariant']);
+
+export default listItemTagClasses;

--- a/components/src/core/ThreeLiner/ThreeLiner.tsx
+++ b/components/src/core/ThreeLiner/ThreeLiner.tsx
@@ -1,58 +1,28 @@
-import React, { HTMLAttributes, ReactNode } from 'react';
-import { Theme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
-import clsx from 'clsx';
+import React, { ReactNode } from 'react';
+import { cx } from '@emotion/css';
+import { Box, BoxProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import threeLinerClasses, {
+    ThreeLinerClasses,
+    ThreeLinerClassKey,
+    getThreeLinerUtilityClass,
+} from './ThreeLinerClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-export type ThreeLinerClasses = {
-    root?: string;
-    title?: string;
-    subtitle?: string;
-    info?: string;
+const useUtilityClasses = (ownerState: ThreeLinerProps): Record<ThreeLinerClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        title: ['title'],
+        subtitle: ['subtitle'],
+        info: ['info'],
+    };
+
+    return composeClasses(slots, getThreeLinerUtilityClass, classes);
 };
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            display: 'flex',
-            height: '100%',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        title: {
-            fontSize: '1.875rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        subtitle: {
-            fontSize: '1rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-        },
-        info: {
-            fontSize: '0.875rem',
-            transition: (props: ThreeLinerProps): string =>
-                theme.transitions.create(['all'], {
-                    duration: props.animationDuration || theme.transitions.duration.standard,
-                    easing: theme.transitions.easing.easeInOut,
-                }),
-            fontWeight: 300,
-        },
-    })
-);
-
-export type ThreeLinerProps = HTMLAttributes<HTMLDivElement> & {
+export type ThreeLinerProps = BoxProps & {
     /** First Line Content */
     title?: ReactNode;
 
@@ -72,6 +42,42 @@ export type ThreeLinerProps = HTMLAttributes<HTMLDivElement> & {
     classes?: Partial<ThreeLinerClasses>;
 };
 
+const Root = styled(Box, {
+    name: 'three-liner',
+    slot: 'root',
+})<Pick<ThreeLinerProps, 'animationDuration'>>(({ animationDuration, theme }) => ({
+    display: 'flex',
+    height: '100%',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    transition: theme.transitions.create(['all'], {
+        duration: animationDuration || theme.transitions.duration.standard,
+        easing: theme.transitions.easing.easeInOut,
+    }),
+    [`& .${threeLinerClasses.title}`]: {
+        fontSize: '1.875rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+    },
+    [`& .${threeLinerClasses.subtitle}`]: {
+        fontSize: '1rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+    },
+    [`& .${threeLinerClasses.info}`]: {
+        fontSize: '0.875rem',
+        transition: theme.transitions.create(['all'], {
+            duration: animationDuration || theme.transitions.duration.standard,
+            easing: theme.transitions.easing.easeInOut,
+        }),
+        fontWeight: 300,
+    },
+}));
+
 const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProps> = (
     props: ThreeLinerProps,
     ref: any
@@ -81,20 +87,25 @@ const ThreeLinerRenderer: React.ForwardRefRenderFunction<unknown, ThreeLinerProp
         subtitle,
         info,
         classes = {},
-        className,
+        className: userClassName,
         // ignore unused vars so that we can do prop transferring to the root element
         /* eslint-disable @typescript-eslint/no-unused-vars */
         animationDuration,
-        ...otherDivProps
+        ...otherProps
     } = props;
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     //const animationDuration = durationProp || theme.transitions.duration.standard;
     return (
-        <div ref={ref} {...otherDivProps} className={clsx(defaultClasses.root, classes.root, className)}>
-            <div className={clsx(defaultClasses.title, classes.title)}>{title}</div>
-            <div className={clsx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
-            <div className={clsx(defaultClasses.info, classes.info)}>{info}</div>
-        </div>
+        <Root
+            ref={ref}
+            {...otherProps}
+            animationDuration={animationDuration}
+            className={cx(defaultClasses.root, classes.root, userClassName)}
+        >
+            <div className={cx(defaultClasses.title, classes.title)}>{title}</div>
+            <div className={cx(defaultClasses.subtitle, classes.subtitle)}>{subtitle}</div>
+            <div className={cx(defaultClasses.info, classes.info)}>{info}</div>
+        </Root>
     );
 };
 /**

--- a/components/src/core/ThreeLiner/ThreeLinerClasses.tsx
+++ b/components/src/core/ThreeLiner/ThreeLinerClasses.tsx
@@ -1,0 +1,29 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export type ThreeLinerClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+    /** First Line Content */
+    title?: string;
+
+    /** Second Line Content */
+    subtitle?: string;
+
+    /** Third Line Content */
+    info?: string;
+};
+
+export type ThreeLinerClassKey = keyof ThreeLinerClasses;
+
+export function getThreeLinerUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiThreeLiner', slot);
+}
+
+const threeLinerClasses: ThreeLinerClasses = generateUtilityClasses('BluiThreeLiner', [
+    'root',
+    'title',
+    'subtitle',
+    'info',
+]);
+
+export default threeLinerClasses;

--- a/components/src/core/Utility/Spacer.tsx
+++ b/components/src/core/Utility/Spacer.tsx
@@ -1,9 +1,21 @@
-import { CSSProperties } from '@mui/styles';
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
+import { Box, BoxProps } from '@mui/material';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { SpacerClasses, getSpacerUtilityClass, SpacerClassKey } from './SpacerClasses';
+import { cx } from '@emotion/css';
+import { styled } from '@mui/material/styles';
 
-export type SpacerProps = HTMLAttributes<HTMLDivElement> & {
+const useUtilityClasses = (ownerState: SpacerProps): Record<SpacerClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+    };
+
+    return composeClasses(slots, getSpacerUtilityClass, classes);
+};
+
+export type SpacerProps = BoxProps & {
     /** Flex grow/shrink value for flex layouts
      *
      * Default: 1
@@ -15,32 +27,36 @@ export type SpacerProps = HTMLAttributes<HTMLDivElement> & {
     width?: number | string;
     /** Custom classes for default style overrides */
     classes?: SpacerClasses;
-    style?: CSSProperties;
 };
-export type SpacerClasses = {
-    root?: string;
-};
+
+const Root = styled(Box, {
+    name: 'spacer',
+    slot: 'root',
+})<Pick<SpacerProps, 'flex' | 'height' | 'width'>>(({ flex, height, width }) => ({
+    flex: `${flex} ${flex} ${flex === 0 ? 'auto' : '0px'}`,
+    height: height || 'auto',
+    width: width || 'auto',
+}));
 
 const SpacerRender: React.ForwardRefRenderFunction<unknown, SpacerProps> = (props: SpacerProps, ref: any) => {
-    const { children, classes, flex, height, style, width, ...otherDivProps } = props;
+    const { children, classes, flex, height, width, ...otherProps } = props;
+    const ownerState = {
+        ...props,
+    };
+    const defaultClasses = useUtilityClasses(ownerState);
 
     return (
-        <div
+        <Root
             ref={ref}
             data-test={'spacer-root'}
-            className={clsx(classes.root)}
-            style={Object.assign(
-                {
-                    flex: `${flex} ${flex} ${flex === 0 ? 'auto' : '0px'}`,
-                    height: height || 'auto',
-                    width: width || 'auto',
-                },
-                { ...style }
-            )}
-            {...otherDivProps}
+            flex={flex}
+            height={height}
+            width={width}
+            className={cx(defaultClasses.root, classes.root)}
+            {...otherProps}
         >
             {children}
-        </div>
+        </Root>
     );
 };
 /**

--- a/components/src/core/Utility/SpacerClasses.tsx
+++ b/components/src/core/Utility/SpacerClasses.tsx
@@ -1,0 +1,12 @@
+import { generateUtilityClass } from '@mui/base';
+
+export type SpacerClasses = {
+    /** Styles applied to the root element. */
+    root?: string;
+};
+
+export type SpacerClassKey = keyof SpacerClasses;
+
+export function getSpacerUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiSpacer', slot);
+}

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -372,6 +372,17 @@
     "@emotion/weak-memoize" "^0.2.5"
     stylis "4.0.13"
 
+"@emotion/css@^11.9.0":
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/@emotion/css/-/css-11.9.0.tgz#d5aeaca5ed19fc61cbdc9e032ad0b32fa6e366be"
+  integrity sha512-S9UjCxSrxEHawOLnWw4upTwfYKb0gVQdatHejn3W9kPyXxmKv3HmjVfJ84kDLmdX8jR20OuDQwaJ4Um24qD9vA==
+  dependencies:
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.7.1"
+    "@emotion/serialize" "^1.0.3"
+    "@emotion/sheet" "^1.0.3"
+    "@emotion/utils" "^1.0.0"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -413,7 +424,18 @@
     "@emotion/utils" "^1.0.0"
     csstype "^3.0.2"
 
-"@emotion/sheet@^1.1.0":
+"@emotion/serialize@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.3.tgz#99e2060c26c6292469fb30db41f4690e1c8fea63"
+  integrity sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/sheet@^1.0.3", "@emotion/sheet@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -3429,9 +3429,9 @@ minimatch@^3.0.4, minimatch@^3.1.2:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 moo@^0.5.0:
   version "0.5.1"

--- a/demos/storybook/yarn.lock
+++ b/demos/storybook/yarn.lock
@@ -9389,9 +9389,9 @@ locate-path@^5.0.0:
     p-locate "^4.1.0"
 
 lodash-es@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
-  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -9828,9 +9828,9 @@ minimatch@3.0.4, minimatch@^3.0.2, minimatch@^3.0.4, minimatch@~3.0.2:
     brace-expansion "^1.1.7"
 
 minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -43,9 +43,40 @@ Any other props supplied will be provided to the root element (`span`).
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. It supports the following keys:
 
-| Name  | Description                         |
-| ----- | ----------------------------------- |
-| root  | Styles applied to the root element  |
-| icon  | Styles applied to the icon element  |
-| units | Styles applied to the units element |
-| value | Styles applied to the value element |
+| Name   | Description                                               |
+| ------ | --------------------------------------------------------- |
+| root   | Styles applied to the root element                        |
+| icon   | Styles applied to the icon element                        |
+| text   | Styles applied to the text element                        |
+| prefix | Styles applied to the units element when used as a prefix |
+| suffix | Styles applied to the units element when used as a suffix |
+| units  | Styles applied to the units element                       |
+| value  | Styles applied to the value element                       |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop. It supports the following classNames:
+
+| Global CSS Class         | Description                                               |
+| ------------------------ | --------------------------------------------------------- |
+| .BluiChannelValue-icon   | Styles applied to the icon element                        |
+| .BluiChannelValue-text   | Styles applied to the text element                        |
+| .BluiChannelValue-prefix | Styles applied to the units element when used as a prefix |
+| .BluiChannelValue-suffix | Styles applied to the units element when used as a suffix |
+| .BluiChannelValue-units  | Styles applied to the units element                       |
+| .BluiChannelValue-value  | Styles applied to the value element                       |
+
+```tsx
+import { ChannelValue } from '@brightlayer-ui/react-components';
+...
+<ChannelValue
+    value={100}
+    units={'%'}
+    icon={<Icon/>}
+    sx={{
+        ml: 1,
+        mr: 1,
+        '& .BluiChannelValue-icon': { ml: '2px', fontSize: '1rem' }
+    }}
+/>
+```

--- a/docs/EmptyState.md
+++ b/docs/EmptyState.md
@@ -45,3 +45,18 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | description | Styles applied to the description  |
 | icon        | Styles applied to the icon         |
 | title       | Styles applied to the title        |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import { EmptyState } from '@brightlayer-ui/react-components';
+import NotListedLocation from '@mui/icons-material/NotListedLocation';
+...
+<EmptyState
+    sx={{margin: '0px'}}
+    icon={<NotListedLocation />}
+    title={'Location Unknown'}
+/>
+```

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -40,3 +40,19 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | Name | Description                        |
 | ---- | ---------------------------------- |
 | root | Styles applied to the root element |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import * as colors from '@brightlayer-ui/colors';
+import { Spacer } from '@brightlayer-ui/react-components';
+
+<Spacer 
+    width={60} 
+    height={50} 
+    sx={{ background: colors.red[300], display: 'inline-block' }}>
+    {/* Spacer Content */}
+</Spacer>
+```

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -48,8 +48,8 @@ You can override the styles used by Brightlayer UI by passing a `sx` prop. The `
 ```tsx
 import * as colors from '@brightlayer-ui/colors';
 import { Spacer } from '@brightlayer-ui/react-components';
-
+...
 <Spacer width={60} height={50} sx={{ background: colors.red[300], display: 'inline-block' }}>
     {/* Spacer Content */}
-</Spacer>;
+</Spacer>
 ```

--- a/docs/Spacer.md
+++ b/docs/Spacer.md
@@ -49,10 +49,7 @@ You can override the styles used by Brightlayer UI by passing a `sx` prop. The `
 import * as colors from '@brightlayer-ui/colors';
 import { Spacer } from '@brightlayer-ui/react-components';
 
-<Spacer 
-    width={60} 
-    height={50} 
-    sx={{ background: colors.red[300], display: 'inline-block' }}>
+<Spacer width={60} height={50} sx={{ background: colors.red[300], display: 'inline-block' }}>
     {/* Spacer Content */}
-</Spacer>
+</Spacer>;
 ```

--- a/docs/ThreeLiner.md
+++ b/docs/ThreeLiner.md
@@ -25,3 +25,19 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | title    | Styles applied to the first line   |
 | subtitle | Styles applied to the second line  |
 | info     | Styles applied to the third line   |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop.
+
+```tsx
+import { ThreeLiner } from '@brightlayer-ui/react-components';
+import * as colors from '@brightlayer-ui/colors';
+...
+<ThreeLiner
+    sx={{ color: colors.blue[200] }}
+    title={'Three Liner Component'}
+    subtitle={'with basic usage'}
+    info={'...and a third line'}
+/>
+```

--- a/scripts/linkComponents.sh
+++ b/scripts/linkComponents.sh
@@ -15,32 +15,33 @@ yarn build
 cd ..
 
 echo -en "${BLUE}Creating new folder in node_modules...${NC}"
+rm -rf "./demos/showcase/node_modules/.cache"
 rm -rf "./demos/showcase/node_modules/@brightlayer-ui/react-components"
 mkdir -p "./demos/showcase/node_modules/@brightlayer-ui/react-components"
-rm -rf "./demos/storybook/node_modules/@brightlayer-ui/react-components"
-mkdir -p "./demos/storybook/node_modules/@brightlayer-ui/react-components"
+# rm -rf ./demos/storybook/node_modules/@brightlayer-ui/react-components
+# mkdir -p ./demos/storybook/node_modules/@brightlayer-ui/react-components
 echo -e "${GREEN}Done${NC}"
 
 echo -en "${BLUE}Copying build output into node_modules...${NC}";
 cp -r ./components/package.json ./demos/showcase/node_modules/@brightlayer-ui/react-components/package.json
 cp -r ./dist/. ./demos/showcase/node_modules/@brightlayer-ui/react-components
-cp -r ./components/package.json ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json
-cp -r ./dist/. ./demos/storybook/node_modules/@brightlayer-ui/react-components
+# cp -r ./components/package.json ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json
+# cp -r ./dist/. ./demos/storybook/node_modules/@brightlayer-ui/react-components
 echo -e "${GREEN}Done${NC}"
 
 echo -en "\r\n${BLUE}Linking Components: ${NC}"
 if [ ! -f ./demos/showcase/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
-if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
+# if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/package.json ]; then echo -e "${BRED}Not Linked${NC}" && exit 1; fi
 if [ ! -s ./demos/showcase/node_modules/@brightlayer-ui/react-components ];
     then
         if [ ! -f ./demos/showcase/node_modules/@brightlayer-ui/react-components/index.js ];
         then echo -e "${BRED}Not Linked${NC}" && exit 1;
         fi;
 fi
-if [ ! -s ./demos/storybook/node_modules/@brightlayer-ui/react-components ];
-    then
-        if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/index.js ];
-        then echo -e "${BRED}Not Linked${NC}" && exit 1;
-        fi;
-fi
+# if [ ! -s ./demos/storybook/node_modules/@brightlayer-ui/react-components ];
+#     then
+#         if [ ! -f ./demos/storybook/node_modules/@brightlayer-ui/react-components/index.js ];
+#         then echo -e "${BRED}Not Linked${NC}" && exit 1;
+#         fi;
+# fi
 echo -e "${GRAY}Complete${NC}\r\n"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3056
Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop

Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. I will work on documentation while this is in draft review.