### PR TITLE
3052 drawer layout style updates

### DIFF
--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -59,20 +59,19 @@ const Content = styled(Box, {
     zIndex: 0,
 }));
 
-export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> &
-    BoxProps & {
-        /** Custom classes for default style overrides */
-        classes?: DrawerLayoutClasses;
+export type DrawerLayoutProps = BoxProps & {
+    /** Custom classes for default style overrides */
+    classes?: DrawerLayoutClasses;
 
-        /** Drawer component to be embedded */
-        drawer: ReactElement<DrawerComponentProps>;
-    };
+    /** Drawer component to be embedded */
+    drawer: ReactElement<DrawerComponentProps>;
+};
 
 const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutProps> = (
     props: DrawerLayoutProps,
     ref: any
 ) => {
-    const { children, drawer, classes, className: userClassName, ...otherDivProps } = props;
+    const { children, drawer, classes, className: userClassName, ...otherProps } = props;
     const theme = useTheme();
     const [padding, setPadding] = useState<number | string>(0);
     const [drawerOpen, setDrawerOpen] = useState(false);
@@ -100,7 +99,7 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
                     },
                     userClassName
                 )}
-                {...otherDivProps}
+                {...otherProps}
             >
                 <Drawer className={cx(defaultClasses.drawer, classes.drawer)}>{drawer}</Drawer>
                 <Content className={cx(defaultClasses.content, classes.content)} style={style}>

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -28,7 +28,7 @@ const useUtilityClasses = (ownerState: DrawerLayoutProps): Record<DrawerLayoutCl
 const Root = styled(Box, {
     name: 'drawer-layout',
     slot: 'root',
-})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+})(({ theme }) => ({
     display: 'flex',
     width: '100%',
     '&$expanded $content': {
@@ -42,7 +42,7 @@ const Root = styled(Box, {
 const Drawer = styled(Box, {
     name: 'drawer-layout',
     slot: 'drawer',
-})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+})(({ theme }) => ({
     display: 'flex',
     position: 'fixed',
     height: '100%',
@@ -53,7 +53,7 @@ const Drawer = styled(Box, {
 const Content = styled(Box, {
     name: 'drawer-layout',
     slot: 'content',
-})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+})(({ theme }) => ({
     width: '100%',
     transition: theme.transitions.create('padding', { duration: theme.transitions.duration.leavingScreen }),
     zIndex: 0,

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, HTMLAttributes, useState, CSSProperties } from 'react';
+import React, { ReactElement, useState, CSSProperties } from 'react';
 import { useTheme } from '@mui/material/styles';
 import PropTypes from 'prop-types';
 import { DrawerProps as DrawerComponentProps } from '../Drawer/Drawer';

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import { DrawerProps as DrawerComponentProps } from '../Drawer/Drawer';
 import { DrawerLayoutContext } from './contexts/DrawerLayoutContextProvider';
 import { cx } from '@emotion/css';
-import { Box, BoxProps } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import { Box, BoxProps, styled } from '@mui/material';
 import drawerLayoutClasses, {
     DrawerLayoutClasses,
     DrawerLayoutClassKey,

--- a/components/src/core/DrawerLayout/DrawerLayout.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayout.tsx
@@ -1,70 +1,83 @@
 import React, { ReactElement, HTMLAttributes, useState, CSSProperties } from 'react';
-import { Theme, useTheme } from '@mui/material/styles';
-import makeStyles from '@mui/styles/makeStyles';
-import createStyles from '@mui/styles/createStyles';
+import { useTheme } from '@mui/material/styles';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { DrawerProps as DrawerComponentProps } from '../Drawer/Drawer';
 import { DrawerLayoutContext } from './contexts/DrawerLayoutContextProvider';
+import { cx } from '@emotion/css';
+import { Box, BoxProps } from '@mui/material';
+import { styled } from '@mui/material/styles';
+import drawerLayoutClasses, {
+    DrawerLayoutClasses,
+    DrawerLayoutClassKey,
+    getDrawerLayoutUtilityClass,
+} from './DrawerLayoutClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            display: 'flex',
-            width: '100%',
-            '&$expanded $content': {
-                transition: theme.transitions.create('padding', {
-                    duration: theme.transitions.duration.enteringScreen,
-                }),
-            },
-        },
-        content: {
-            width: '100%',
-            transition: theme.transitions.create('padding', { duration: theme.transitions.duration.leavingScreen }),
-            zIndex: 0,
-        },
-        drawer: {
-            display: 'flex',
-            position: 'fixed',
-            height: '100%',
-            alignItems: 'stretch',
-            zIndex: theme.zIndex.drawer,
-        },
-        expanded: {},
-    })
-);
+const useUtilityClasses = (ownerState: DrawerLayoutProps): Record<DrawerLayoutClassKey, string> => {
+    const { classes } = ownerState;
 
-export type DrawerLayoutClasses = {
-    /** Styles applied to the body content container */
-    content?: string;
+    const slots = {
+        root: ['root'],
+        content: ['content'],
+        drawer: ['drawer'],
+        expanded: ['expanded'],
+    };
 
-    /** Styles applied to the drawer container */
-    drawer?: string;
-
-    /** Styles applied to the body root element when the drawer is expanded */
-    expanded?: string;
-
-    /** Styles applied to the root element */
-    root?: string;
+    return composeClasses(slots, getDrawerLayoutUtilityClass, classes);
 };
 
-export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> & {
-    /** Custom classes for default style overrides */
-    classes?: DrawerLayoutClasses;
+const Root = styled(Box, {
+    name: 'drawer-layout',
+    slot: 'root',
+})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+    display: 'flex',
+    width: '100%',
+    '&$expanded $content': {
+        transition: theme.transitions.create('padding', {
+            duration: theme.transitions.duration.enteringScreen,
+        }),
+    },
+    [`& .${drawerLayoutClasses.expanded}`]: {},
+}));
 
-    /** Drawer component to be embedded */
-    drawer: ReactElement<DrawerComponentProps>;
-};
+const Drawer = styled(Box, {
+    name: 'drawer-layout',
+    slot: 'drawer',
+})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+    display: 'flex',
+    position: 'fixed',
+    height: '100%',
+    alignItems: 'stretch',
+    zIndex: theme.zIndex.drawer,
+}));
+
+const Content = styled(Box, {
+    name: 'drawer-layout',
+    slot: 'content',
+})<Pick<DrawerLayoutProps, null>>(({ theme }) => ({
+    width: '100%',
+    transition: theme.transitions.create('padding', { duration: theme.transitions.duration.leavingScreen }),
+    zIndex: 0,
+}));
+
+export type DrawerLayoutProps = HTMLAttributes<HTMLDivElement> &
+    BoxProps & {
+        /** Custom classes for default style overrides */
+        classes?: DrawerLayoutClasses;
+
+        /** Drawer component to be embedded */
+        drawer: ReactElement<DrawerComponentProps>;
+    };
 
 const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutProps> = (
     props: DrawerLayoutProps,
     ref: any
 ) => {
-    const { children, drawer, classes, ...otherDivProps } = props;
+    const { children, drawer, classes, className: userClassName, ...otherDivProps } = props;
     const theme = useTheme();
     const [padding, setPadding] = useState<number | string>(0);
     const [drawerOpen, setDrawerOpen] = useState(false);
-    const defaultClasses = useStyles();
+    const defaultClasses = useUtilityClasses(props);
 
     const style: CSSProperties = { paddingLeft: 0, paddingRight: 0 };
     style.paddingLeft = theme.direction === 'ltr' ? padding : 0;
@@ -77,19 +90,24 @@ const DrawerLayoutRender: React.ForwardRefRenderFunction<unknown, DrawerLayoutPr
                 setDrawerOpen,
             }}
         >
-            <div
+            <Root
                 ref={ref}
-                className={clsx(defaultClasses.root, classes.root, {
-                    [defaultClasses.expanded]: !drawerOpen,
-                    [classes.expanded]: !drawerOpen,
-                })}
+                className={cx(
+                    defaultClasses.root,
+                    classes.root,
+                    {
+                        [defaultClasses.expanded]: !drawerOpen,
+                        [classes.expanded]: !drawerOpen,
+                    },
+                    userClassName
+                )}
                 {...otherDivProps}
             >
-                <div className={clsx(defaultClasses.drawer, classes.drawer)}>{drawer}</div>
-                <div className={clsx(defaultClasses.content, classes.content)} style={style}>
+                <Drawer className={cx(defaultClasses.drawer, classes.drawer)}>{drawer}</Drawer>
+                <Content className={cx(defaultClasses.content, classes.content)} style={style}>
                     {children}
-                </div>
-            </div>
+                </Content>
+            </Root>
         </DrawerLayoutContext.Provider>
     );
 };

--- a/components/src/core/DrawerLayout/DrawerLayoutClasses.tsx
+++ b/components/src/core/DrawerLayout/DrawerLayoutClasses.tsx
@@ -1,0 +1,27 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/base';
+
+export type DrawerLayoutClasses = {
+    /** Styles applied to the root element */
+    root?: string;
+    /** Styles applied to the body content container */
+    content?: string;
+    /** Styles applied to the drawer container */
+    drawer?: string;
+    /** Styles applied to the body root element when the drawer is expanded */
+    expanded?: string;
+};
+
+export type DrawerLayoutClassKey = keyof DrawerLayoutClasses;
+
+export function getDrawerLayoutUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiDrawerLayout', slot);
+}
+
+const drawerLayoutClasses: DrawerLayoutClasses = generateUtilityClasses('BluiDrawerLayout', [
+    'root',
+    'content',
+    'drawer',
+    'expanded',
+]);
+
+export default drawerLayoutClasses;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-3052.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update drawerLayout to use muiv5 styles

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- There isn't a drawerLayout demo in the showcase so you can test using the main drawer in the app using the showcase branch `feature/3052-drawer-layout-style-updates` 
- I've added some styles you can edit and comment out to test the hierarchy of specificity as well as general working functionality.
