### PR TITLE
Feature/3051 drawer comp mui style engine

### DIFF
--- a/components/src/core/Drawer/DrawerBody.tsx
+++ b/components/src/core/Drawer/DrawerBody.tsx
@@ -1,37 +1,45 @@
-import React, { HTMLAttributes } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import makeStyles from '@mui/styles/makeStyles';
 import { DrawerNavGroup, DrawerNavGroupProps } from './DrawerNavGroup';
 import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from './types';
 import { mergeStyleProp } from './utilities';
-import clsx from 'clsx';
+import Box, { BoxProps } from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
+import { DrawerBodyClasses, DrawerBodyClassKey, getDrawerBodyUtilityClass } from './DrawerBodyClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { cx } from '@emotion/css';
 
-type DrawerBodyClasses = {
-    root?: string;
+const useUtilityClasses = (ownerState: DrawerBodyProps): Record<DrawerBodyClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+    };
+
+    return composeClasses(slots, getDrawerBodyUtilityClass, classes);
 };
 
-export type DrawerBodyProps = HTMLAttributes<HTMLDivElement> &
+export type DrawerBodyProps = BoxProps &
     SharedStyleProps &
     NavItemSharedStyleProps & {
         /** Custom classes for default style overrides */
         classes?: DrawerBodyClasses;
     };
 
-const useStyles = makeStyles({
-    root: {
+const Root = styled(Box, { name: 'drawer-body', slot: 'root' })<Pick<DrawerBodyProps, 'backgroundColor'>>(
+    ({ backgroundColor }) => ({
         display: 'flex',
         flex: '1 1 0px',
         flexDirection: 'column',
         overflowY: 'auto',
-        backgroundColor: (props: DrawerBodyProps): string => props.backgroundColor,
-    },
-});
+        backgroundColor: backgroundColor,
+    })
+);
 
 const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps> = (
     bodyProps: DrawerBodyProps,
     ref: any
 ) => {
-    const defaultClasses = useStyles(bodyProps);
+    const defaultClasses = useUtilityClasses(bodyProps);
     const {
         // Inheritable Props
         activeItemBackgroundColor,
@@ -54,14 +62,14 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
         // DrawerBody-specific props
         classes,
         children: bodyChildren,
-        // Other div props
-        ...otherDivProps
+        // Other props
+        ...otherProps
     } = bodyProps;
 
     const children = React.Children.toArray(bodyChildren);
 
     return (
-        <div ref={ref} className={clsx(defaultClasses.root, classes.root)} {...otherDivProps}>
+        <Root ref={ref} className={cx(defaultClasses.root, classes.root)} backgroundColor={backgroundColor} {...otherProps}>
             {children.map((child: any, index: number) => {
                 if (!child) {
                     return null;
@@ -104,7 +112,7 @@ const DrawerBodyRender: React.ForwardRefRenderFunction<unknown, DrawerBodyProps>
                     />
                 );
             })}
-        </div>
+        </Root>
     );
 };
 

--- a/components/src/core/Drawer/DrawerBodyClasses.tsx
+++ b/components/src/core/Drawer/DrawerBodyClasses.tsx
@@ -1,0 +1,15 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
+
+export type DrawerBodyClasses = {
+    root?: string;
+};
+
+export type DrawerBodyClassKey = keyof DrawerBodyClasses;
+
+export function getDrawerBodyUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiDrawerBody', slot);
+}
+
+const drawerBodyClasses: DrawerBodyClasses = generateUtilityClasses('BluiDrawerBody', ['root']);
+
+export default drawerBodyClasses;

--- a/components/src/core/Drawer/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader.tsx
@@ -1,25 +1,36 @@
 import React, { ReactNode, useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { Theme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
 import Toolbar, { ToolbarProps } from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Divider from '@mui/material/Divider';
 import IconButton from '@mui/material/IconButton';
 import { useDrawerContext } from './DrawerContext';
+import drawerHeaderClasses, {
+    DrawerHeaderClasses,
+    DrawerHeaderClassKey,
+    getDrawerHeaderUtilityClass,
+} from './DrawerHeaderClasses';
+import { cx } from '@emotion/css';
 import clsx from 'clsx';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
 
-type DrawerHeaderClasses = {
-    root?: string;
-    background?: string;
-    content?: string;
-    navigation?: string;
-    nonCLickable?: string;
-    nonClickableIcon?: string;
-    railIcon?: string;
-    subtitle?: string;
-    title?: string;
+const useUtilityClasses = (ownerState: DrawerHeaderProps): Record<DrawerHeaderClassKey, string> => {
+    const { classes } = ownerState;
+    const slots = {
+        root: ['root'],
+        background: ['background'],
+        content: ['content'],
+        navigation: ['navigation'],
+        nonCLickable: ['nonCLickable'],
+        nonClickableIcon: ['nonClickableIcon'],
+        railIcon: ['railIcon'],
+        subtitle: ['subtitle'],
+        title: ['title'],
+    };
+
+    return composeClasses(slots, getDrawerHeaderUtilityClass, classes);
 };
 
 export type DrawerHeaderProps = ToolbarProps & {
@@ -56,90 +67,94 @@ export type DrawerHeaderProps = ToolbarProps & {
     titleContent?: ReactNode;
 };
 
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            paddingRight: 0,
-            paddingLeft: 0,
-            width: '100%',
-            alignItems: 'center',
-            boxSizing: 'border-box',
-            minHeight: `4rem`,
-            [theme.breakpoints.down('sm')]: {
-                minHeight: `3.5rem`,
-            },
-            backgroundColor: (props: DrawerHeaderProps): string =>
-                props.backgroundColor ||
-                (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main),
-            color: (props: DrawerHeaderProps): string =>
-                props.fontColor ||
-                theme.palette.getContrastText(
-                    props.backgroundColor ||
-                        (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main)
-                ),
+const Root = styled(Toolbar, { name: 'drawer-header', slot: 'root' })<
+    Pick<DrawerHeaderProps, 'backgroundColor' | 'fontColor'>
+>(({ backgroundColor, fontColor, theme }) => ({
+    paddingRight: 0,
+    paddingLeft: 0,
+    width: '100%',
+    alignItems: 'center',
+    boxSizing: 'border-box',
+    minHeight: `4rem`,
+    [theme.breakpoints.down('sm')]: {
+        minHeight: `3.5rem`,
+    },
+    backgroundColor:
+        backgroundColor || (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main),
+    color:
+        fontColor ||
+        theme.palette.getContrastText(
+            backgroundColor || (theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main)
+        ),
+    [`& .${drawerHeaderClasses.nonCLickable}`]: {},
+    [`& .${drawerHeaderClasses.railIcon}`]: {
+        marginLeft: theme.spacing(0.5),
+        minWidth: 'calc(3.5rem + 16px)',
+        justifyContent: 'center',
+        '&$nonClickable': {
+            marginLeft: 0,
         },
-        background: {
-            position: 'absolute',
-            zIndex: 0,
-            width: '100%',
-            backgroundSize: 'cover',
-            height: '100%',
-            backgroundPosition: 'center',
-            backgroundImage: (props: DrawerHeaderProps): string => `url(${props.backgroundImage})`,
-            opacity: (props: DrawerHeaderProps): number => props.backgroundOpacity,
-        },
-        content: {
-            marginLeft: theme.spacing(2),
-            paddingRight: theme.spacing(2),
-            minHeight: '4rem',
-            display: 'flex',
-            justifyContent: 'center',
-            alignSelf: 'stretch',
-            flexDirection: 'column',
-            width: 'calc(100% - 2.5rem - 32px)',
-            boxSizing: 'border-box',
-            zIndex: 1,
-            [theme.breakpoints.down('sm')]: {
-                minHeight: `3.5rem`,
-            },
-        },
-        navigation: {
-            marginLeft: theme.spacing(2),
-            minWidth: '2.5rem',
-            height: '100%',
-            display: 'flex',
-            alignItems: 'center',
-            zIndex: 1,
-        },
-        nonClickable: {},
-        nonClickableIcon: {
-            display: 'flex',
-            padding: 0,
-        },
-        railIcon: {
-            marginLeft: theme.spacing(0.5),
-            minWidth: 'calc(3.5rem + 16px)',
-            justifyContent: 'center',
-            '&$nonClickable': {
-                marginLeft: 0,
-            },
-        },
-        subtitle: {
-            lineHeight: '1.2rem', // Anything lower than 1.2rem cuts off bottom text of 'g' or 'y'.
-            marginTop: '-0.125rem',
-        },
-        title: {
-            fontWeight: 600,
-            lineHeight: '1.6rem', // Anything lower than 1.6rem cuts off bottom text of 'g' or 'y'.
-        },
-    })
-);
+    },
+}));
+
+const Background = styled(Box, { name: 'drawer-header', slot: 'background' })<
+    Pick<DrawerHeaderProps, 'backgroundImage' | 'backgroundOpacity'>
+>(({ backgroundImage, backgroundOpacity }) => ({
+    position: 'absolute',
+    zIndex: 0,
+    width: '100%',
+    backgroundSize: 'cover',
+    height: '100%',
+    backgroundPosition: 'center',
+    backgroundImage: `url(${backgroundImage})`,
+    opacity: backgroundOpacity,
+}));
+
+const Navigation = styled(Box, { name: 'drawer-header', slot: 'navigation' })(({ theme }) => ({
+    marginLeft: theme.spacing(2),
+    minWidth: '2.5rem',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    zIndex: 1,
+}));
+
+const Content = styled(Box, { name: 'drawer-header', slot: 'content' })(({ theme }) => ({
+    marginLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    minHeight: '4rem',
+    display: 'flex',
+    justifyContent: 'center',
+    alignSelf: 'stretch',
+    flexDirection: 'column',
+    width: 'calc(100% - 2.5rem - 32px)',
+    boxSizing: 'border-box',
+    zIndex: 1,
+    [theme.breakpoints.down('sm')]: {
+        minHeight: `3.5rem`,
+    },
+}));
+
+const Title = styled(Typography, { name: 'drawer-header', slot: 'title' })(() => ({
+    fontWeight: 600,
+    lineHeight: '1.6rem', // Anything lower than 1.6rem cuts off bottom text of 'g' or 'y'.
+}));
+
+const Subtitle = styled(Typography, { name: 'drawer-header', slot: 'subtitle' })(() => ({
+    lineHeight: '1.2rem', // Anything lower than 1.2rem cuts off bottom text of 'g' or 'y'.
+    marginTop: '-0.125rem',
+}));
+
+const NonClickableIcon = styled(Box, { name: 'drawer-header', slot: 'nonClickableIcon' })(() => ({
+    display: 'flex',
+    padding: 0,
+}));
 
 const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderProps> = (
     props: DrawerHeaderProps,
     ref: any
 ) => {
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     const {
         backgroundImage,
         classes,
@@ -155,7 +170,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
         backgroundOpacity,
         fontColor,
         /* eslint-enable @typescript-eslint/no-unused-vars */
-        ...otherToolbarProps
+        ...otherProps
     } = props;
 
     const { variant = 'persistent', condensed = false } = useDrawerContext();
@@ -163,47 +178,59 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
     const getHeaderContent = useCallback(
         (): ReactNode =>
             titleContent || (
-                <div className={clsx(defaultClasses.content, classes.content)}>
-                    <Typography
+                <Content className={cx(defaultClasses.content, classes.content)}>
+                    <Title
                         noWrap
                         variant={'h6'}
-                        className={clsx(defaultClasses.title, classes.title)}
+                        className={cx(defaultClasses.title, classes.title)}
                         data-test={'drawer-header-title'}
                     >
                         {title}
-                    </Typography>
+                    </Title>
 
                     {subtitle && (
-                        <Typography
+                        <Subtitle
                             noWrap
                             variant={'body2'}
-                            className={clsx(defaultClasses.subtitle, classes.subtitle)}
+                            className={cx(defaultClasses.subtitle, classes.subtitle)}
                             data-test={'drawer-header-subtitle'}
                         >
                             {subtitle}
-                        </Typography>
+                        </Subtitle>
                     )}
-                </div>
+                </Content>
             ),
         [defaultClasses, classes, title, subtitle, titleContent]
     );
 
     const getBackgroundImage = useCallback(
         (): JSX.Element | null =>
-            backgroundImage ? <div className={clsx(defaultClasses.background, classes.background)} /> : null,
+            backgroundImage ? (
+                <Background
+                    className={cx(defaultClasses.background, classes.background)}
+                    backgroundImage={backgroundImage}
+                    backgroundOpacity={backgroundOpacity}
+                />
+            ) : null,
         [backgroundImage, defaultClasses, classes]
     );
 
     return (
         <>
-            <Toolbar ref={ref} className={clsx(defaultClasses.root, classes.root)} {...otherToolbarProps}>
+            <Root
+                ref={ref}
+                className={cx(defaultClasses.root, classes.root)}
+                backgroundColor={backgroundColor}
+                fontColor={fontColor}
+                {...otherProps}
+            >
                 {getBackgroundImage()}
                 {icon && (
-                    <div
+                    <Navigation
                         className={clsx(defaultClasses.navigation, classes.navigation, {
                             [defaultClasses.railIcon]: variant === 'rail' && !condensed,
                             [classes.railIcon]: variant === 'rail' && !condensed && classes.railIcon,
-                            [defaultClasses.nonClickable]: variant === 'rail' && !condensed && !onIconClick,
+                            [defaultClasses.nonCLickable]: variant === 'rail' && !condensed && !onIconClick,
                         })}
                     >
                         {onIconClick && (
@@ -219,14 +246,14 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                             </IconButton>
                         )}
                         {!onIconClick && (
-                            <div className={clsx(defaultClasses.nonClickableIcon, classes.nonClickableIcon)}>
+                            <NonClickableIcon className={cx(defaultClasses.nonClickableIcon, classes.nonClickableIcon)}>
                                 {icon}
-                            </div>
+                            </NonClickableIcon>
                         )}
-                    </div>
+                    </Navigation>
                 )}
                 {getHeaderContent()}
-            </Toolbar>
+            </Root>
             {divider && <Divider />}
         </>
     );

--- a/components/src/core/Drawer/DrawerHeaderClasses.tsx
+++ b/components/src/core/Drawer/DrawerHeaderClasses.tsx
@@ -1,0 +1,33 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
+
+export type DrawerHeaderClasses = {
+    root?: string;
+    background?: string;
+    content?: string;
+    navigation?: string;
+    nonCLickable?: string;
+    nonClickableIcon?: string;
+    railIcon?: string;
+    subtitle?: string;
+    title?: string;
+};
+
+export type DrawerHeaderClassKey = keyof DrawerHeaderClasses;
+
+export function getDrawerHeaderUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiDrawerHeader', slot);
+}
+
+const drawerHeaderClasses: DrawerHeaderClasses = generateUtilityClasses('BluiDrawerHeader', [
+    'root',
+    'background',
+    'content',
+    'navigation',
+    'nonCLickable',
+    'nonClickableIcon',
+    'railIcon',
+    'subtitle',
+    'title',
+]);
+
+export default drawerHeaderClasses;


### PR DESCRIPTION
Fixes # BLUI-3051

DrawerBody and DrawerHeader

Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop

Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. I will work on documentation while this is in draft review.