### PR TITLE
Clean up ChannelValue styles

### DIFF
--- a/components/src/core/ChannelValue/ChannelValue.tsx
+++ b/components/src/core/ChannelValue/ChannelValue.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 import Typography from '@mui/material/Typography';
 import { cx } from '@emotion/css';
 import PropTypes from 'prop-types';
-import { Box, BoxProps } from '@mui/material';
+import { Box, BoxProps, TypographyProps } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import channelValueClasses, {
     ChannelValueClasses,
@@ -18,8 +18,6 @@ const useUtilityClasses = (ownerState: ChannelValueProps): Record<ChannelValueCl
         root: ['root'],
         icon: ['icon'],
         text: ['text'],
-        prefix: ['prefix'],
-        suffix: ['suffix'],
         value: ['value'],
         units: ['units'],
     };
@@ -61,10 +59,7 @@ export type ChannelValueProps = Omit<BoxProps, 'prefix'> & {
     value: number | string;
 };
 
-const Root = styled(Box, {
-    name: 'channel-value',
-    slot: 'root',
-})<Pick<ChannelValueProps, 'fontSize' | 'color'>>(({ fontSize, color }) => ({
+const Root = styled(Box)<Pick<ChannelValueProps, 'fontSize' | 'color'>>(({ fontSize, color }) => ({
     display: 'inline-flex',
     alignItems: 'center',
     lineHeight: 1.2,
@@ -76,7 +71,7 @@ const Root = styled(Box, {
 const IconSpan = styled('span', {
     name: 'channel-value',
     slot: 'icon',
-})<Pick<ChannelValueProps, null>>(() => ({
+})(() => ({
     marginRight: '0.35em',
     display: 'inline',
     fontSize: 'inherit',
@@ -85,24 +80,23 @@ const IconSpan = styled('span', {
 const Unit = styled(Typography, {
     name: 'channel-value',
     slot: 'units',
-})<Pick<ChannelValueProps, null>>(() => ({
+    shouldForwardProp: (prop) => prop !== 'isSuffix',
+})<TypographyProps & { isSuffix: boolean }>(({ isSuffix }) => ({
     fontWeight: 300,
-    [`& .${channelValueClasses.suffix}`]: {},
-    [`& .${channelValueClasses.prefix}`]: {
-        '& + h6': {
-            marginLeft: '0.25em',
-        },
-    },
+    ...(isSuffix === true && {
+        marginLeft: '0.25em',
+    }),
 }));
 
 const Value = styled(Typography, {
     name: 'channel-value',
     slot: 'value',
-})<Pick<ChannelValueProps, null>>(() => ({
+    shouldForwardProp: (prop) => prop !== 'isPrefix',
+})<TypographyProps & { isPrefix: boolean }>(({ isPrefix }) => ({
     fontWeight: 600,
-    '& + $suffix': {
+    ...(isPrefix === true && {
         marginLeft: '0.25em',
-    },
+    }),
 }));
 
 const changeIconDisplay = (newIcon: JSX.Element): JSX.Element =>
@@ -122,11 +116,8 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
         units,
         unitSpace,
         value,
-        // ignore unused vars so that we can do prop transferring to the root element
-        /* eslint-disable @typescript-eslint/no-unused-vars */
         color,
         fontSize,
-        /* eslint-enable @typescript-eslint/no-unused-vars */
         ...otherProps
     } = props;
     const defaultClasses = useUtilityClasses(props);
@@ -152,20 +143,8 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                     <Unit
                         variant={'h6'}
                         color={'inherit'}
-                        className={cx(
-                            defaultClasses.text,
-                            classes.text,
-                            defaultClasses.units,
-                            classes.units,
-                            {
-                                [defaultClasses.prefix]: applyPrefix(),
-                                [defaultClasses.suffix]: applySuffix(),
-                            },
-                            {
-                                [classes.prefix]: applyPrefix(),
-                                [classes.suffix]: applySuffix(),
-                            }
-                        )}
+                        className={cx(defaultClasses.text, classes.text, defaultClasses.units, classes.units)}
+                        isSuffix={applySuffix()}
                         data-test={'units'}
                     >
                         {units}
@@ -197,6 +176,7 @@ const ChannelValueRender: React.ForwardRefRenderFunction<unknown, ChannelValuePr
                 color={'inherit'}
                 className={cx(defaultClasses.text, classes.text, defaultClasses.value, classes.value)}
                 data-test={'value'}
+                isPrefix={applyPrefix()}
             >
                 {value}
             </Value>

--- a/components/src/core/ChannelValue/ChannelValueClasses.tsx
+++ b/components/src/core/ChannelValue/ChannelValueClasses.tsx
@@ -7,10 +7,6 @@ export type ChannelValueClasses = {
     icon?: string;
     /** Styles applied to the text element. */
     text?: string;
-    /** Styles applied to the prefix element. */
-    prefix?: string;
-    /** Styles applied to the suffix element. */
-    suffix?: string;
     /** Styles applied to the units element. */
     units?: string;
     /** Styles applied to the value element. */
@@ -27,8 +23,6 @@ const channelValueClasses: ChannelValueClasses = generateUtilityClasses('BluiCha
     'root',
     'icon',
     'text',
-    'prefix',
-    'suffix',
     'units',
     'value',
 ]);

--- a/docs/ChannelValue.md
+++ b/docs/ChannelValue.md
@@ -48,21 +48,17 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 | root   | Styles applied to the root element                        |
 | icon   | Styles applied to the icon element                        |
 | text   | Styles applied to the text element                        |
-| prefix | Styles applied to the units element when used as a prefix |
-| suffix | Styles applied to the units element when used as a suffix |
 | units  | Styles applied to the units element                       |
 | value  | Styles applied to the value element                       |
 
 ### `sx` Class Overrides
 
-You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `Classes` prop. It supports the following classNames:
+You can override the styles used by Brightlayer UI by passing a `sx` prop. It supports the following classNames:
 
 | Global CSS Class         | Description                                               |
 | ------------------------ | --------------------------------------------------------- |
 | .BluiChannelValue-icon   | Styles applied to the icon element                        |
 | .BluiChannelValue-text   | Styles applied to the text element                        |
-| .BluiChannelValue-prefix | Styles applied to the units element when used as a prefix |
-| .BluiChannelValue-suffix | Styles applied to the units element when used as a suffix |
 | .BluiChannelValue-units  | Styles applied to the units element                       |
 | .BluiChannelValue-value  | Styles applied to the value element                       |
 


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Clean up channel value styles to conditionally add styles instead of classes
- Remove unnecessary classes
- Update docs

The `unitSpace` and `prefix` should be tested throughly giving mind to the prefix and suffix allowList.

Some test cases to get you through...
```
<ChannelValue value={'123'} units={'hz'} unitSpace={'auto'} />
<ChannelValue value={'123'} units={'hz'} unitSpace={'hide'} />
<ChannelValue value={'123'} units={'hz'} unitSpace={'show'} />
<ChannelValue value={'1200'} units={'$'} prefix />
<ChannelValue value={'98'} units={'°F'} />
<ChannelValue value={'23'} units={'℃'} />
<ChannelValue value={'98'} units={'°F'} unitSpace={'show'} />
<ChannelValue value={'23'} units={'℃'} unitSpace={'show'} />
```