### PR TITLE
Feature/3118 drawer nav group style engine

### DIFF
--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -141,7 +141,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
         nestedBackgroundColor,
         nestedDivider,
         ripple,
-        ...otherListProps
+        ...otherProps
     } = props;
 
     const { variant, open: drawerOpen = true, activeItem } = useDrawerContext();
@@ -262,7 +262,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                         </SubHeader>
                     )
                 }
-                {...otherListProps}
+                {...otherProps}
             >
                 {variant !== 'rail' && (
                     <div key={`${title}_title`}>{(title || titleContent) && titleDivider && <Divider />}</div>

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -50,7 +50,7 @@ export type DrawerNavGroupProps = SharedStyleProps &
     };
 
 const Root = styled(List, {
-    name: 'drawer-layout',
+    name: 'drawer-nav-group',
     slot: 'root',
 })<Pick<DrawerNavGroupProps, 'backgroundColor'>>(({ backgroundColor }) => ({
     backgroundColor: backgroundColor,
@@ -59,8 +59,8 @@ const Root = styled(List, {
 }));
 
 const SubHeader = styled(ListSubheader, {
-    name: 'drawer-layout',
-    slot: 'root',
+    name: 'drawer-nav-group',
+    slot: 'subheader',
 })(({ theme }) => ({
     paddingBottom: 0,
     paddingLeft: theme.spacing(2),
@@ -70,8 +70,8 @@ const SubHeader = styled(ListSubheader, {
 }));
 
 const Title = styled(Typography, {
-    name: 'drawer-layout',
-    slot: 'root',
+    name: 'drawer-nav-group',
+    slot: 'title',
 })(() => ({
     display: 'block',
     alignItems: 'center',

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -118,6 +118,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
         // Nav Group Props
         children,
         classes,
+        className: userClassName,
         items = [],
         title,
         titleColor = theme.palette.text.primary,
@@ -244,7 +245,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
         <NavGroupContext.Provider value={{ activeHierarchy: activeHierarchyItems }}>
             <Root
                 ref={ref}
-                className={cx(defaultClasses.root, classes.root)}
+                className={cx(defaultClasses.root, classes.root, userClassName)}
                 subheader={
                     variant !== 'rail' && (
                         <SubHeader

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -262,6 +262,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                         </SubHeader>
                     )
                 }
+                backgroundColor={backgroundColor}
                 {...otherProps}
             >
                 {variant !== 'rail' && (

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -1,19 +1,31 @@
 import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import { useDrawerContext } from './DrawerContext';
-import { NavGroupContext } from './NavGroupContext';
-import { Theme, useTheme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
+import { useDrawerContext } from '../DrawerContext';
+import { NavGroupContext } from '../NavGroupContext';
+import { useTheme, styled } from '@mui/material/styles';
 import List, { ListProps } from '@mui/material/List';
 import Typography from '@mui/material/Typography';
 import ListSubheader from '@mui/material/ListSubheader';
 import Divider from '@mui/material/Divider';
-import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from './types';
-import { DrawerNavItem, DrawerNavItemProps, NestedDrawerNavItemProps } from './DrawerNavItem';
-import { DrawerRailItem, DrawerRailItemProps } from './DrawerRailItem';
-import { findChildByType, mergeStyleProp } from './utilities';
-import clsx from 'clsx';
+import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from '../types';
+import { DrawerNavItem, DrawerNavItemProps, NestedDrawerNavItemProps } from '../DrawerNavItem';
+import { DrawerRailItem, DrawerRailItemProps } from '../DrawerRailItem';
+import { findChildByType, mergeStyleProp } from '../utilities';
+import { cx } from '@emotion/css';
+import { DrawerNavGroupClasses, DrawerNavGroupClassKey, getDrawerNavGroupUtilityClass } from './DrawerNavGroupClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+
+const useUtilityClasses = (ownerState: DrawerNavGroupProps): Record<DrawerNavGroupClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        subheader: ['subheader'],
+        title: ['title'],
+    };
+
+    return composeClasses(slots, getDrawerNavGroupUtilityClass, classes);
+};
 
 export type DrawerNavGroupProps = SharedStyleProps &
     NavItemSharedStyleProps &
@@ -37,34 +49,36 @@ export type DrawerNavGroupProps = SharedStyleProps &
         titleDivider?: boolean;
     };
 
-type DrawerNavGroupClasses = {
-    root?: string;
-    subheader?: string;
-    title?: string;
-};
-const useStyles = makeStyles((theme: Theme) =>
-    createStyles({
-        root: {
-            backgroundColor: (props: DrawerNavGroupProps): string => props.backgroundColor,
-            paddingBottom: 0,
-            paddingTop: 0,
-        },
-        title: {
-            display: 'block',
-            alignItems: 'center',
-            lineHeight: '3rem',
-            height: `3rem`,
-            fontWeight: 600,
-        },
-        subheader: {
-            paddingBottom: 0,
-            paddingLeft: theme.spacing(2),
-            paddingRight: theme.spacing(2),
-            position: 'inherit',
-            cursor: 'text',
-        },
-    })
-);
+const Root = styled(List, {
+    name: 'drawer-layout',
+    slot: 'root',
+})<Pick<DrawerNavGroupProps, 'backgroundColor'>>(({ backgroundColor }) => ({
+    backgroundColor: backgroundColor,
+    paddingBottom: 0,
+    paddingTop: 0,
+}));
+
+const SubHeader = styled(ListSubheader, {
+    name: 'drawer-layout',
+    slot: 'root',
+})(({ theme }) => ({
+    paddingBottom: 0,
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    position: 'inherit',
+    cursor: 'text',
+}));
+
+const Title = styled(Typography, {
+    name: 'drawer-layout',
+    slot: 'root',
+})(() => ({
+    display: 'block',
+    alignItems: 'center',
+    lineHeight: '3rem',
+    height: `3rem`,
+    fontWeight: 600,
+}));
 
 const findID = (item: DrawerNavItemProps | NestedDrawerNavItemProps, activeItem: string): boolean => {
     // if leaf node, return
@@ -98,7 +112,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
     props: DrawerNavGroupProps,
     ref: any
 ) => {
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     const theme = useTheme();
     const {
         // Nav Group Props
@@ -228,28 +242,24 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
 
     return (
         <NavGroupContext.Provider value={{ activeHierarchy: activeHierarchyItems }}>
-            <List
+            <Root
                 ref={ref}
-                className={clsx(defaultClasses.root, classes.root)}
+                className={cx(defaultClasses.root, classes.root)}
                 subheader={
                     variant !== 'rail' && (
-                        <ListSubheader
-                            className={clsx(defaultClasses.subheader, classes.subheader)}
+                        <SubHeader
+                            className={cx(defaultClasses.subheader, classes.subheader)}
                             style={{
                                 color: drawerOpen ? titleColor : 'transparent',
                             }}
                         >
                             {title && (
-                                <Typography
-                                    noWrap
-                                    variant={'overline'}
-                                    className={clsx(defaultClasses.title, classes.title)}
-                                >
+                                <Title noWrap variant={'overline'} className={cx(defaultClasses.title, classes.title)}>
                                     {title}
-                                </Typography>
+                                </Title>
                             )}
                             {titleContent}
-                        </ListSubheader>
+                        </SubHeader>
                     )
                 }
                 {...otherListProps}
@@ -342,7 +352,7 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                     );
                 })}
                 {getChildren()}
-            </List>
+            </Root>
         </NavGroupContext.Provider>
     );
 };

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroupClasses.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroupClasses.tsx
@@ -1,0 +1,21 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
+
+export type DrawerNavGroupClasses = {
+    root?: string;
+    subheader?: string;
+    title?: string;
+};
+
+export type DrawerNavGroupClassKey = keyof DrawerNavGroupClasses;
+
+export function getDrawerNavGroupUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiDrawerNavGroup', slot);
+}
+
+const drawerNavGroupClasses: DrawerNavGroupClasses = generateUtilityClasses('BluiDrawerNavGroup', [
+    'root',
+    'subheader',
+    'title',
+]);
+
+export default drawerNavGroupClasses;

--- a/components/src/core/Drawer/DrawerNavGroup/index.ts
+++ b/components/src/core/Drawer/DrawerNavGroup/index.ts
@@ -1,0 +1,1 @@
+export * from './DrawerNavGroup';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3118
DrawerNavGroup

Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop

Test:
There is a showcase branch feature/3050-channel-value-mui-v5-styles-update that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. 
