### PR TITLE
Updated DrawerRailItem to work with mui v5 style engine

### DIFF
--- a/components/src/core/AppBar/AppBar.tsx
+++ b/components/src/core/AppBar/AppBar.tsx
@@ -26,6 +26,7 @@ const useUtilityClasses = (ownerState: AppBarProps): Record<AppBarClassKey, stri
 const Root = styled(MuiAppBar, {
     name: 'app-bar',
     slot: 'root',
+    shouldForwardProp: (prop) => prop !== 'backgroundImage',
 })<Pick<AppBarProps, 'animationDuration' | 'backgroundImage'>>(({ animationDuration, backgroundImage, theme }) => ({
     overflow: 'hidden',
     transition: theme.transitions.create(['height'], {

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -52,6 +52,7 @@ export type DrawerNavGroupProps = SharedStyleProps &
 const Root = styled(List, {
     name: 'drawer-nav-group',
     slot: 'root',
+    shouldForwardProp: (prop) => prop !== 'backgroundColor',
 })<Pick<DrawerNavGroupProps, 'backgroundColor'>>(({ backgroundColor }) => ({
     backgroundColor: backgroundColor,
     paddingBottom: 0,

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -184,6 +184,7 @@ const StatusStripe = styled(Box, {
 const Icon = styled(Avatar, {
     name: 'drawer-rail-item',
     slot: 'icon',
+    shouldForwardProp: (prop) => prop !== 'itemIconColor',
 })<Pick<DrawerRailItemProps, 'itemIconColor'>>(({ itemIconColor, theme }) => ({
     color: itemIconColor || theme.palette.text.primary,
     backgroundColor: 'transparent',

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -88,7 +88,11 @@ export type DrawerRailItemProps = SharedStyleProps & {
 const Root = styled(ButtonBase, {
     name: 'drawer-rail-item',
     slot: 'root',
-    shouldForwardProp: (prop) => prop !== 'backgroundColor',
+    shouldForwardProp: (prop) =>
+        prop !== 'backgroundColor' &&
+        prop !== 'activeItemIconColor' &&
+        prop !== 'activeItemFontColor' &&
+        prop !== 'statusColor',
 })<
     Pick<
         DrawerRailItemProps,
@@ -171,6 +175,7 @@ const ActiveItem = styled(Box, {
 const StatusStripe = styled(Box, {
     name: 'drawer-rail-item',
     slot: 'statusStripe',
+    shouldForwardProp: (prop) => prop !== 'statusColor',
 })<Pick<DrawerRailItemProps, 'statusColor'>>(({ statusColor }) => ({
     position: 'absolute',
     top: 0,
@@ -196,6 +201,7 @@ const Icon = styled(Avatar, {
 const Title = styled(Typography, {
     name: 'drawer-rail-item',
     slot: 'title',
+    shouldForwardProp: (prop) => prop !== 'itemFontColor',
 })<Pick<DrawerRailItemProps, 'itemFontColor'>>(({ itemFontColor, theme }) => ({
     lineHeight: '1rem',
     wordBreak: 'break-word',

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -18,7 +18,7 @@ import drawerRailItemClasses, {
     getDrawerRailItemUtilityClass,
 } from './DrawerRailItemClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { styled } from '@mui/material/styles';
+import { styled, SxProps, Theme } from '@mui/material/styles';
 import Box from '@mui/material/Box';
 
 const useUtilityClasses = (ownerState: DrawerRailItemProps): Record<DrawerRailItemClassKey, string> => {
@@ -80,6 +80,9 @@ export type DrawerRailItemProps = SharedStyleProps & {
 
     /** Sets whether to disable the tooltip on hover */
     disableRailTooltip?: boolean;
+
+    /** Optional sx props to apply style overrides */
+    sx?: SxProps<Theme>;
 };
 
 const Root = styled(ButtonBase, {
@@ -198,6 +201,9 @@ const Title = styled(Typography, {
     hyphens: 'auto',
     zIndex: 200,
     color: itemFontColor || theme.palette.text.primary,
+    [`& .${drawerRailItemClasses.titleActive}`]: {
+        fontWeight: 600,
+    },
 }));
 
 const DrawerRailItemDivider = styled(Divider, {
@@ -208,9 +214,6 @@ const DrawerRailItemDivider = styled(Divider, {
     bottom: 0,
     left: 0,
     width: '100%',
-    [`& .${drawerRailItemClasses.itemActive}`]: {
-        fontWeight: 600,
-    },
 }));
 
 const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailItemProps> = (
@@ -234,6 +237,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
         icon,
         itemID,
         onClick,
+        sx,
         // onItemSelect,
         title = '',
         ButtonBaseProps,
@@ -304,6 +308,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             activeItemFontColor={activeItemFontColor}
             disableRipple={!ripple || !hasAction}
             onClick={onClickAction}
+            sx={sx}
             {...RippleProps}
         >
             {/* Active Item Highlight */}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -1,30 +1,44 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { useDrawerContext } from './DrawerContext';
-import { Theme } from '@mui/material/styles';
-import createStyles from '@mui/styles/createStyles';
-import makeStyles from '@mui/styles/makeStyles';
+import { useDrawerContext } from '../DrawerContext';
 import Avatar from '@mui/material/Avatar';
 import ButtonBase, { ButtonBaseProps as MuiButtonBaseProps } from '@mui/material/ButtonBase';
 import Divider from '@mui/material/Divider';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
-import { RAIL_WIDTH, RAIL_WIDTH_CONDENSED } from './Drawer';
-import { SharedStyleProps, SharedStylePropTypes } from './types';
-import { NavItem } from './DrawerNavItem';
+import { RAIL_WIDTH, RAIL_WIDTH_CONDENSED } from '../Drawer';
+import { SharedStyleProps, SharedStylePropTypes } from '../types';
+import { NavItem } from '../DrawerNavItem';
 import color from 'color';
 import clsx from 'clsx';
+import { cx } from '@emotion/css';
+import drawerRailItemClasses, {
+    DrawerRailItemClasses,
+    DrawerRailItemClassKey,
+    getDrawerRailItemUtilityClass,
+} from './DrawerRailItemClasses';
+import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
 
-export type DrawerRailItemClasses = {
-    root?: string;
-    active?: string;
-    condensed?: string;
-    divider?: string;
-    icon?: string;
-    statusStripe?: string;
-    title?: string;
-    titleActive?: string;
-    ripple?: string;
+const useUtilityClasses = (ownerState: DrawerRailItemProps): Record<DrawerRailItemClassKey, string> => {
+    const { classes } = ownerState;
+
+    const slots = {
+        root: ['root'],
+        active: ['active'],
+        condensed: ['condensed'],
+        divider: ['divider'],
+        icon: ['icon'],
+        statusStripe: ['statusStripe'],
+        title: ['title'],
+        titleActive: ['titleActive'],
+        ripple: ['ripple'],
+        cursorPointer: ['cursorPointer'],
+        itemActive: ['itemActive'],
+    };
+
+    return composeClasses(slots, getDrawerRailItemUtilityClass, classes);
 };
 
 export type ExtendedNavItem = NavItem & { ButtonBaseProps?: Partial<MuiButtonBaseProps> };
@@ -68,14 +82,66 @@ export type DrawerRailItemProps = SharedStyleProps & {
     disableRailTooltip?: boolean;
 };
 
-const useStyles = makeStyles<Theme, DrawerRailItemProps>((theme: Theme) => {
-    // approximates the [200] color but not perfectly because the theme does not have that explicit color
+const Root = styled(ButtonBase, {
+    name: 'drawer-rail-item',
+    slot: 'root',
+    shouldForwardProp: (prop) => prop !== 'backgroundColor',
+})<
+    Pick<
+        DrawerRailItemProps,
+        'statusColor' | 'backgroundColor' | 'onClick' | 'activeItemIconColor' | 'activeItemFontColor'
+    >
+>(({ statusColor, backgroundColor, onClick, activeItemIconColor, activeItemFontColor, theme }) => {
     const lightenedPrimary = color(
         theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main
     )
         .lighten(0.83)
         .desaturate(0.39)
         .string();
+    return {
+        width: RAIL_WIDTH,
+        minHeight: RAIL_WIDTH,
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'default',
+        padding: `1rem ${statusColor ? theme.spacing(1) : theme.spacing(0.5)}px`,
+        textAlign: 'center',
+        backgroundColor: backgroundColor || 'transparent',
+        '&:hover': {
+            backgroundColor: onClick ? theme.palette.action.hover : undefined,
+        },
+        [`& .${drawerRailItemClasses.cursorPointer}`]: {
+            cursor: 'pointer',
+        },
+        [`& .${drawerRailItemClasses.itemActive}`]: {
+            '& $icon': {
+                color:
+                    activeItemIconColor ||
+                    (theme.palette.mode === 'light' ? theme.palette.primary.main : lightenedPrimary),
+            },
+            '& $title': {
+                color:
+                    activeItemFontColor ||
+                    (theme.palette.mode === 'light' ? theme.palette.primary.main : lightenedPrimary),
+            },
+        },
+        [`& .${drawerRailItemClasses.condensed}`]: {
+            width: RAIL_WIDTH_CONDENSED,
+            minHeight: RAIL_WIDTH_CONDENSED,
+        },
+        [`& .${drawerRailItemClasses.ripple}`]: {
+            backgroundColor: theme.palette.primary.main,
+        },
+    };
+});
+
+const ActiveItem = styled(Box, {
+    name: 'drawer-rail-item',
+    slot: 'active',
+})<Pick<DrawerRailItemProps, 'activeItemBackgroundColor'>>(({ activeItemBackgroundColor, theme }) => {
     const fivePercentOpacityPrimary = color(
         theme.palette.mode === 'dark' ? theme.palette.primary.dark : theme.palette.primary.main
     )
@@ -87,89 +153,65 @@ const useStyles = makeStyles<Theme, DrawerRailItemProps>((theme: Theme) => {
         .fade(0.8)
         .string();
 
-    return createStyles({
-        root: {
-            width: RAIL_WIDTH,
-            minHeight: RAIL_WIDTH,
-            position: 'relative',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'default',
-            padding: (props): string => `1rem ${props.statusColor ? theme.spacing(1) : theme.spacing(0.5)}px`,
-            textAlign: 'center',
-            backgroundColor: (props): string => props.backgroundColor || 'transparent',
-            '&:hover': {
-                backgroundColor: (props): string => (props.onClick ? theme.palette.action.hover : undefined),
-            },
-        },
-        active: {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            backgroundColor: (props): string =>
-                props.activeItemBackgroundColor ||
-                (theme.palette.mode === 'light' ? fivePercentOpacityPrimary : twentyPercentOpacityPrimary),
-        },
-        condensed: {
-            width: RAIL_WIDTH_CONDENSED,
-            minHeight: RAIL_WIDTH_CONDENSED,
-        },
-        cursorPointer: {
-            cursor: 'pointer',
-        },
-        divider: {
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            width: '100%',
-        },
-        icon: {
-            color: (props): string => props.itemIconColor || theme.palette.text.primary,
-            backgroundColor: 'transparent',
-            height: 'auto',
-            width: 'auto',
-            overflow: 'visible',
-        },
-        itemActive: {
-            '& $icon': {
-                color: (props): string =>
-                    props.activeItemIconColor ||
-                    (theme.palette.mode === 'light' ? theme.palette.primary.main : lightenedPrimary),
-            },
-            '& $title': {
-                color: (props): string =>
-                    props.activeItemFontColor ||
-                    (theme.palette.mode === 'light' ? theme.palette.primary.main : lightenedPrimary),
-            },
-        },
-        ripple: {
-            backgroundColor: theme.palette.primary.main,
-        },
-        statusStripe: {
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: 0,
-            width: 6,
-            zIndex: 100,
-            backgroundColor: (props): string => props.statusColor,
-        },
-        title: {
-            lineHeight: '1rem',
-            wordBreak: 'break-word',
-            hyphens: 'auto',
-            zIndex: 200,
-            color: (props): string => props.itemFontColor || theme.palette.text.primary,
-        },
-        titleActive: {
-            fontWeight: 600,
-        },
-    });
+    return {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor:
+            activeItemBackgroundColor ||
+            (theme.palette.mode === 'light' ? fivePercentOpacityPrimary : twentyPercentOpacityPrimary),
+    };
 });
+
+const StatusStripe = styled(Box, {
+    name: 'drawer-rail-item',
+    slot: 'statusStripe',
+})<Pick<DrawerRailItemProps, 'statusColor'>>(({ statusColor }) => ({
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    width: 6,
+    zIndex: 100,
+    backgroundColor: statusColor,
+}));
+
+const Icon = styled(Avatar, {
+    name: 'drawer-rail-item',
+    slot: 'icon',
+})<Pick<DrawerRailItemProps, 'itemIconColor'>>(({ itemIconColor, theme }) => ({
+    color: itemIconColor || theme.palette.text.primary,
+    backgroundColor: 'transparent',
+    height: 'auto',
+    width: 'auto',
+    overflow: 'visible',
+}));
+
+const Title = styled(Typography, {
+    name: 'drawer-rail-item',
+    slot: 'title',
+})<Pick<DrawerRailItemProps, 'itemFontColor'>>(({ itemFontColor, theme }) => ({
+    lineHeight: '1rem',
+    wordBreak: 'break-word',
+    hyphens: 'auto',
+    zIndex: 200,
+    color: itemFontColor || theme.palette.text.primary,
+}));
+
+const DrawerRailItemDivider = styled(Divider, {
+    name: 'drawer-rail-item',
+    slot: 'divider',
+})(() => ({
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    width: '100%',
+    [`& .${drawerRailItemClasses.itemActive}`]: {
+        fontWeight: 600,
+    },
+}));
 
 const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailItemProps> = (
     props: DrawerRailItemProps,
@@ -203,7 +245,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
     const { activeItem, onItemSelect, condensed: drawerCondensed = false } = useDrawerContext();
     const active = activeItem === itemID;
     const condensed = itemCondensed !== undefined ? itemCondensed : drawerCondensed;
-    const defaultClasses = useStyles(props);
+    const defaultClasses = useUtilityClasses(props);
     const hasAction = Boolean(onClick || onItemSelect);
 
     // Customize the color of the Touch Ripple
@@ -212,20 +254,20 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             ? {
                   TouchRippleProps: {
                       classes: {
-                          child: clsx(defaultClasses.ripple, classes.ripple),
+                          child: cx(defaultClasses.ripple, classes.ripple),
                       },
                   },
               }
             : {};
 
     const combine = useCallback(
-        (className: keyof DrawerRailItemClasses): string => clsx(defaultClasses[className], classes[className]),
+        (className: keyof DrawerRailItemClasses): string => cx(defaultClasses[className], classes[className]),
         [defaultClasses, classes]
     );
 
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
-            return <Avatar className={combine('icon')}>{icon}</Avatar>;
+            return <Icon className={combine('icon')}>{icon}</Icon>;
         }
     }, [icon, combine]);
 
@@ -242,7 +284,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
     );
 
     const innerContent = (
-        <ButtonBase
+        <Root
             ref={ref}
             {...ButtonBaseProps}
             {...directButtonBaseProps}
@@ -257,16 +299,16 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && <div className={combine('active')} />}
+            {active && <ActiveItem className={combine('active')} />}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <div className={combine('statusStripe')} data-test={'status-stripe'} />
+                <StatusStripe className={combine('statusStripe')} data-test={'status-stripe'} />
             )}
             {/* Icon */}
             {getIcon()}
             {/* Title */}
             {!condensed && (
-                <Typography
+                <Title
                     variant={'caption'}
                     className={clsx(defaultClasses.title, classes.title, {
                         [defaultClasses.titleActive]: active,
@@ -274,11 +316,11 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                     })}
                 >
                     {title}
-                </Typography>
+                </Title>
             )}
             {/* Divider */}
-            {divider && <Divider className={combine('divider')} />}
-        </ButtonBase>
+            {divider && <DrawerRailItemDivider className={combine('divider')} />}
+        </Root>
     );
 
     return hidden ? null : condensed && !disableRailTooltip ? (

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -267,7 +267,11 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
 
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
-            return <Icon className={combine('icon')} itemIconColor={itemIconColor}>{icon}</Icon>;
+            return (
+                <Icon className={combine('icon')} itemIconColor={itemIconColor}>
+                    {icon}
+                </Icon>
+            );
         }
     }, [icon, combine]);
 
@@ -303,10 +307,16 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && <ActiveItem className={combine('active')} activeItemBackgroundColor={activeItemBackgroundColor} />}
+            {active && (
+                <ActiveItem className={combine('active')} activeItemBackgroundColor={activeItemBackgroundColor} />
+            )}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <StatusStripe className={combine('statusStripe')} data-test={'status-stripe'} statusColor={statusColor}/>
+                <StatusStripe
+                    className={combine('statusStripe')}
+                    data-test={'status-stripe'}
+                    statusColor={statusColor}
+                />
             )}
             {/* Icon */}
             {getIcon()}

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItem.tsx
@@ -267,7 +267,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
 
     const getIcon = useCallback((): JSX.Element | undefined => {
         if (icon) {
-            return <Icon className={combine('icon')}>{icon}</Icon>;
+            return <Icon className={combine('icon')} itemIconColor={itemIconColor}>{icon}</Icon>;
         }
     }, [icon, combine]);
 
@@ -294,15 +294,19 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                 [defaultClasses.condensed]: condensed,
                 [classes.condensed]: condensed && classes.condensed,
             })}
+            statusColor={statusColor}
+            backgroundColor={backgroundColor}
+            activeItemIconColor={activeItemIconColor}
+            activeItemFontColor={activeItemFontColor}
             disableRipple={!ripple || !hasAction}
             onClick={onClickAction}
             {...RippleProps}
         >
             {/* Active Item Highlight */}
-            {active && <ActiveItem className={combine('active')} />}
+            {active && <ActiveItem className={combine('active')} activeItemBackgroundColor={activeItemBackgroundColor} />}
             {/* Status Color Stripe */}
             {statusColor !== undefined && statusColor !== '' && (
-                <StatusStripe className={combine('statusStripe')} data-test={'status-stripe'} />
+                <StatusStripe className={combine('statusStripe')} data-test={'status-stripe'} statusColor={statusColor}/>
             )}
             {/* Icon */}
             {getIcon()}
@@ -314,6 +318,7 @@ const DrawerRailItemRender: React.ForwardRefRenderFunction<unknown, DrawerRailIt
                         [defaultClasses.titleActive]: active,
                         [classes.titleActive]: active && classes.titleActive,
                     })}
+                    itemFontColor={itemFontColor}
                 >
                     {title}
                 </Title>

--- a/components/src/core/Drawer/DrawerRailItem/DrawerRailItemClasses.tsx
+++ b/components/src/core/Drawer/DrawerRailItem/DrawerRailItemClasses.tsx
@@ -1,0 +1,37 @@
+import { generateUtilityClass, generateUtilityClasses } from '@mui/material';
+
+export type DrawerRailItemClasses = {
+    root?: string;
+    active?: string;
+    condensed?: string;
+    divider?: string;
+    icon?: string;
+    statusStripe?: string;
+    title?: string;
+    titleActive?: string;
+    ripple?: string;
+    cursorPointer?: string;
+    itemActive?: string;
+};
+
+export type DrawerRailItemClassKey = keyof DrawerRailItemClasses;
+
+export function getDrawerRailItemUtilityClass(slot: string): string {
+    return generateUtilityClass('BluiDrawerRailItem', slot);
+}
+
+const drawerRailItemClasses: DrawerRailItemClasses = generateUtilityClasses('BluiDrawerRailItem', [
+    'root',
+    'active',
+    'condensed',
+    'divider',
+    'icon',
+    'statusStripe',
+    'title',
+    'titleActive',
+    'ripple',
+    'cursorPointer',
+    'itemActive',
+]);
+
+export default drawerRailItemClasses;

--- a/components/src/core/Drawer/DrawerRailItem/index.ts
+++ b/components/src/core/Drawer/DrawerRailItem/index.ts
@@ -1,0 +1,1 @@
+export * from './DrawerRailItem';

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -386,17 +386,48 @@ When using the `rail` variant of the `<Drawer>`, you should use `<DrawerRailItem
 
 You can override the classes used by Brightlayer UI by passing a `classes` prop. The `<DrawerRailItem>` supports the following keys:
 
-| Name         | Description                                                     |
-| ------------ | --------------------------------------------------------------- |
-| root         | Styles applied to the root element wrapping the InfoListItem    |
-| active       | Styles applied to the active item highlight element             |
-| condensed    | Styles applied to the root element when condensed is true       |
-| divider      | Styles applied to the divider element                           |
-| icon         | Styles applied to the icon wrapper                              |
-| statusStripe | Styles applied to the status stripe                             |
-| title        | Styles applied to the title text                                |
-| titleActive  | Styles applied to the title text if the item is the active item |
-| ripple       | Styles applied to the ripple                                    |
+| Name          | Description                                                     |
+| ------------- | --------------------------------------------------------------- |
+| root          | Styles applied to the root element wrapping the InfoListItem    |
+| active        | Styles applied to the active item highlight element             |
+| condensed     | Styles applied to the root element when condensed is true       |
+| divider       | Styles applied to the divider element                           |
+| icon          | Styles applied to the icon wrapper                              |
+| statusStripe  | Styles applied to the status stripe                             |
+| title         | Styles applied to the title text                                |
+| titleActive   | Styles applied to the title text if the item is the active item |
+| ripple        | Styles applied to the ripple                                    |
+| cursorPointer | Styles applied to the root element when cursor is pointer       |
+| itemActive    | Styles applied to the active item                               |
+
+### `sx` Class Overrides
+
+You can override the styles used by Brightlayer UI by passing a `sx` prop. It supports the following classNames:
+
+| Global CSS Class                  | Description                                                     |
+| --------------------------------- | --------------------------------------------------------------- |
+| .BluiDrawerRailItem-root          | Styles applied to the root element                              |
+| .BluiDrawerRailItem-active        | Styles applied to the active element                            |
+| .BluiDrawerRailItem-condensed     | Styles applied to the root element when condensed is true       |
+| .BluiDrawerRailItem-divider       | Styles applied to the divider element                           |
+| .BluiDrawerRailItem-icon          | Styles applied to the icon wrapper                              |
+| .BluiDrawerRailItem-statusStripe  | Styles applied to the status stripe                             |
+| .BluiDrawerRailItem-title         | Styles applied to the title text                                |
+| .BluiDrawerRailItem-titleActive   | Styles applied to the title text if the item is the active item |
+| .BluiDrawerRailItem-ripple        | Styles applied to the ripple                                    |
+| .BluiDrawerRailItem-cursorPointer | Styles applied to the root element when cursor is pointer       |
+| .BluiDrawerRailItem-itemActive    | Styles applied to the active item                               |
+
+```tsx
+import { DrawerRailItem } from '@brightlayer-ui/react-components';
+import Menu from '@mui/icons-material/Menu';
+...
+ <DrawerRailItem
+    itemID="itemID"
+    icon={<Menu />}
+    sx={{ backgroundColor: 'red' }}
+/>
+```
 
 ### Tips
 


### PR DESCRIPTION
Fixes # BLUI-3122
Changes proposed in this Pull Request:
Update styles to use Mui-v5 Styled components
Update component to extend sx prop

Test:
There is a showcase branch feature/3122-drawer-rail-item-example-showcase that you can use to test this.
When testing, ensure that there are no breaking changes and that the old API properties still work the same and that you can still style things with inline styles as well as using our classes prop.
Also, test out the new sx prop extension. You can apply styles to the root by using sx directly on the component as well as by targeting nested items by the generated classnames. 