### PR TITLE
Bug/3158 438 fix drawer header padding

### DIFF
--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -224,7 +224,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                 backgroundColor={backgroundColor}
                 fontColor={fontColor}
                 sx={sx}
-                style={{paddingLeft: 0, paddingRight: 0}}
+                style={{ paddingLeft: 0, paddingRight: 0 }}
                 {...otherToolbarProps}
             >
                 {getBackgroundImage()}

--- a/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
+++ b/components/src/core/Drawer/DrawerHeader/DrawerHeader.tsx
@@ -72,8 +72,6 @@ export type DrawerHeaderProps = ToolbarProps & {
 const Root = styled(Toolbar, { name: 'drawer-header', slot: 'root' })<
     Pick<DrawerHeaderProps, 'backgroundColor' | 'fontColor'>
 >(({ backgroundColor, fontColor, theme }) => ({
-    paddingRight: 0,
-    paddingLeft: 0,
     width: '100%',
     alignItems: 'center',
     boxSizing: 'border-box',
@@ -226,6 +224,7 @@ const DrawerHeaderRender: React.ForwardRefRenderFunction<unknown, DrawerHeaderPr
                 backgroundColor={backgroundColor}
                 fontColor={fontColor}
                 sx={sx}
+                style={{paddingLeft: 0, paddingRight: 0}}
                 {...otherToolbarProps}
             >
                 {getBackgroundImage()}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes brightlayer-ui/react-showcase-demo#66 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Updated padding left and padding right to pass through style props

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Before:
<img width="260" alt="Screenshot 2022-05-24 at 3 12 54 PM" src="https://user-images.githubusercontent.com/25982779/170023495-2709c4be-7f8a-4e40-a4d1-89a59a615fcc.png">

After:
<img width="267" alt="Screenshot 2022-05-24 at 4 54 24 PM" src="https://user-images.githubusercontent.com/25982779/170023807-4663424c-0d14-4bdd-b7fe-5a60bde585a8.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase
