### PR TITLE
Fixed passing style to DrawerNavItem

### DIFF
--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -96,7 +96,7 @@ export type DrawerNavItemProps = SharedStyleProps &
         InfoListItemProps?: Partial<BLUIInfoListItemProps>;
         /** Optional sx props to apply style overrides */
         sx?: SxProps<Theme>;
-    } & Pick<BoxProps, 'children'>;
+    } & Pick<BoxProps, 'children' | 'style'>;
 export type NestedDrawerNavItemProps = Omit<DrawerNavItemProps, 'icon'>;
 // aliases
 export type NavItem = DrawerNavItemProps;

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -11,7 +11,6 @@ import ArrowDropDown from '@mui/icons-material/ArrowDropDown';
 import ChevronRight from '@mui/icons-material/ChevronRight';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import { NavItemSharedStyleProps, NavItemSharedStylePropTypes, SharedStyleProps, SharedStylePropTypes } from '../types';
-import clsx from 'clsx';
 import color from 'color';
 import { findChildByType, mergeStyleProp } from '../utilities';
 import { white, darkBlack } from '@brightlayer-ui/colors';

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -392,6 +392,8 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                               notifyActiveParent: (ids: string[] = []): void => {
                                   notifyActiveParent(ids.concat(itemID));
                               },
+                              sx: mergeStyleProp(sx, child.props.sx),
+                              style: mergeStyleProp(style, child.props.style),
                           } as DrawerNavItemProps)
                         : React.cloneElement(child, {
                               // Inherited Props
@@ -406,6 +408,8 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
                               itemFontColor: mergeStyleProp(itemFontColor, child.props.itemFontColor),
                               itemIconColor: mergeStyleProp(itemIconColor, child.props.itemIconColor),
                               ripple: mergeStyleProp(ripple, child.props.ripple),
+                              sx: mergeStyleProp(sx, child.props.sx),
+                              style: mergeStyleProp(style, child.props.style),
                           } as DrawerRailItemProps)
                 ),
         [

--- a/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
+++ b/components/src/core/Drawer/DrawerNavItem/DrawerNavItem.tsx
@@ -273,6 +273,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
         subtitle: itemSubtitle,
         title: itemTitle,
         sx,
+        style,
     } = props;
 
     const [expanded, setExpanded] = useState(isInActiveTree);
@@ -453,7 +454,7 @@ const DrawerNavItemRender: React.ForwardRefRenderFunction<HTMLElement, DrawerNav
             {!props.hidden && (
                 <Root
                     ref={ref}
-                    style={{ position: 'relative' }}
+                    style={{ ...style, position: 'relative' }}
                     className={cx(defaultClasses.root, className, classes.root)}
                     depth={depth}
                     nestedBackgroundColor={nestedBackgroundColor}

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -384,7 +384,7 @@ You can override the classes used by Brightlayer UI by passing a `classes` prop.
 
 ### `sx` Class Overrides
 
-You can override the styles used by Brightlayer UI by passing a `sx` prop. It supports the following classNames:
+You can override the styles used by Brightlayer UI by passing a `sx` prop. The `sx` prop styles will override styles provided through the `classes` prop (with the exception of the `active` class).
 
 | Global CSS Class                      | Description                                                     |
 | ------------------------------------- | --------------------------------------------------------------- |


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #450  BLUI-3120
Style overrides using style object is not working for DrawerNavItem

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added style to DrawerNavItem props
- Passed style to BluiDrawerNavItem-root

### Screenshots:
**Before**
<img width="1777" alt="Screenshot 2022-06-09 at 8 17 38 PM" src="https://user-images.githubusercontent.com/25982779/172877803-feaf1296-bf56-436b-bb18-224948613cf1.png">

**After**
<img width="1792" alt="Screenshot 2022-06-09 at 8 08 04 PM" src="https://user-images.githubusercontent.com/25982779/172877957-1ea4a231-9f84-44ae-8a23-f0605ec4af04.png">
 
<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase
- Checkout bug/3120-drawer-nav-item-example-style-fix in showcase
- Pass style while creating nav item in NavigationDrawer in showcase
- Inspect DrawerNavItem to see style overrides

