### PR TITLE
drawer nav rail item doesnt take in style and sx via navGroup items prop

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-components",
-    "version": "6.1.0-beta.0",
+    "version": "6.1.0-beta.1",
     "description": "React components for Brightlayer UI applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
+++ b/components/src/core/Drawer/DrawerNavGroup/DrawerNavGroup.tsx
@@ -303,6 +303,8 @@ const DrawerNavGroupRender: React.ForwardRefRenderFunction<unknown, DrawerNavGro
                                 statusColor={railItem.statusColor}
                                 title={railItem.title}
                                 disableRailTooltip={railItem.disableRailTooltip}
+                                sx={railItem.sx}
+                                style={railItem.style}
                             />
                         );
                     }


### PR DESCRIPTION
The `DrawerRailNavItem` wasn't accepting style and sx props via the items prop on DrawerNavGroup.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix issue where drawer nav rail item doesnt take in style and sx via navGroup items prop

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
Add some styles and sx overrides in the createNavItems function in the NavigationDrawer.tsx file in the showcase and make sure they work when you switch the drawer variant to rail

```
style: { padding: '40px' },
sx: { backgroundColor: 'red' },
```
![Screen Shot 2022-06-15 at 2 56 45 PM](https://user-images.githubusercontent.com/13989985/173903789-4ef9cf6a-9f2e-4e14-a582-e6411bcdf35e.png)

