### PR TITLE
Feature/3418 drawer footer playground

### DIFF
--- a/docs/src/__configuration__/navigationMenu/navigation.tsx
+++ b/docs/src/__configuration__/navigationMenu/navigation.tsx
@@ -18,10 +18,11 @@ import EmptyStateAPIDocs from '../../componentDocs/EmptyState/markdown/EmptyStat
 // Examples markdown
 import DrawerNavItemExamples from '../../componentDocs/DrawerNavItem/markdown/DrawerNavItemExamples.mdx';
 
-// Components playground components
+// Playground components
 import { DrawerPlaygroundComponent } from '../../componentDocs/Drawer/playground';
 import { DrawerHeaderPlaygroundComponent } from '../../componentDocs/DrawerHeader/playground';
 import { DrawerSubheaderPlaygroundComponent } from '../../componentDocs/DrawerSubheader/playground';
+import { DrawerFooterPlaygroundComponent } from '../../componentDocs/DrawerFooter/playground';
 
 export type SimpleNavItem = {
     title: string;
@@ -183,7 +184,7 @@ export const pageDefinitions: SimpleGroupNavGroupItem[] = [
                             {
                                 title: 'Playground',
                                 url: 'playground',
-                                component: <DummyComponent />,
+                                component: <DrawerFooterPlaygroundComponent />,
                             },
                         ],
                     },

--- a/docs/src/componentDocs/DrawerFooter/playground/DrawerFooterTypes.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/DrawerFooterTypes.tsx
@@ -1,0 +1,46 @@
+import { ComponentType } from '../../../__types__';
+import * as Colors from '@brightlayer-ui/colors';
+
+export const drawerTypes: ComponentType = {
+    componentName: 'Drawer Footer',
+    props: [
+        {
+            propName: 'backgroundColor',
+            inputType: 'colorPicker',
+            inputValue: Colors.white[50],
+            propType: 'string',
+            helperText: 'The color used for the background',
+            required: false,
+        },
+        {
+            propName: 'divider',
+            inputType: 'boolean',
+            inputValue: false,
+            propType: 'boolean',
+            helperText: 'Optional divider which appears above footer',
+            required: false,
+            defaultValue: true,
+        },
+        {
+            propName: 'hideContentOnCollapse',
+            inputType: 'boolean',
+            inputValue: false,
+            propType: 'boolean',
+            helperText: 'Hide footer contents when drawer is closed',
+            required: false,
+            defaultValue: true,
+        },
+    ],
+    otherProps: [
+        {
+            propName: 'open',
+            inputType: 'boolean',
+            inputValue: true,
+            propType: 'boolean',
+            helperText: 'Controls the open/closed state of the drawer',
+            required: false,
+        },
+    ],
+};
+
+export default drawerTypes;

--- a/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/PlaygroundPage.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import DrawerFooterPlayground from './PropsPlayground';
+import { PreviewComponent } from './PreviewComponent';
+
+export const DrawerFooterPlaygroundComponent = (): JSX.Element => (
+    <Box
+        sx={{
+            width: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+        }}
+    >
+        <PreviewComponent />
+        <DrawerFooterPlayground />
+    </Box>
+);

--- a/docs/src/componentDocs/DrawerFooter/playground/PreviewComponent.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/PreviewComponent.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { RootState } from '../../../redux/store';
+import { useAppSelector } from '../../../redux/hooks';
+import {
+    Drawer,
+    DrawerBody,
+    DrawerHeader,
+    DrawerNavGroup,
+    DrawerNavItem,
+    DrawerFooter,
+} from '@brightlayer-ui/react-components';
+import { createProps, hideDefaultPropsFromSnippet, removeEmptyLines } from '../../../shared/utilities';
+import { PropsType } from '../../../__types__';
+import PreviewComponentWithCode from '../../../shared/PreviewComponentWithCode';
+import Box from '@mui/material/Box';
+import Menu from '@mui/icons-material/Menu';
+
+export const PreviewComponent = (): JSX.Element => {
+    const drawerFooterJson = useAppSelector((state: RootState) => state.componentsPropsState.drawerFooterComponent);
+
+    const drawerFooterProps = createProps(drawerFooterJson.props as PropsType[]);
+    const drawerFooterOtherProps = createProps(drawerFooterJson.otherProps as PropsType[]);
+
+    const toggleDefaultProp = (propName: string, currentValue: any): string =>
+        hideDefaultPropsFromSnippet(drawerFooterJson, propName, currentValue, 'props');
+
+    const generateCodeSnippet = (): string => {
+        const jsx = `<Drawer open={${drawerFooterOtherProps.open}}>
+    <DrawerHeader
+        icon={<Menu />}
+        title={'Header Title'}
+    />
+
+    <DrawerBody>
+        <DrawerNavGroup>
+            <DrawerNavItem
+                hidePadding
+                itemID={'Nav Item'}
+                title={'Nav Item'}
+            />
+        </DrawerNavGroup>
+    </DrawerBody>
+    <DrawerFooter
+        backgroundColor="${drawerFooterProps.backgroundColor}"
+        ${toggleDefaultProp('divider', drawerFooterProps.divider)}
+        ${toggleDefaultProp('hideContentOnCollapse', drawerFooterProps.hideContentOnCollapse)}
+    >
+        <Box sx={{p: 2}}>
+            Footer Content Here
+        </Box>
+    </DrawerFooter>
+</Drawer>`;
+
+        return removeEmptyLines(jsx);
+    };
+    return (
+        <PreviewComponentWithCode
+            previewContent={
+                <Drawer open={drawerFooterOtherProps.open} noLayout sx={{ minHeight: 'auto' }}>
+                    <DrawerHeader icon={<Menu />} title={'Header Title'} />
+
+                    <DrawerBody sx={{ flex: '1 1 auto' }} backgroundColor={'transparent'}>
+                        <DrawerNavGroup>
+                            <DrawerNavItem hidePadding itemID={'Nav Item'} title={'Nav Item'} />
+                        </DrawerNavGroup>
+                    </DrawerBody>
+                    <DrawerFooter
+                        backgroundColor={drawerFooterProps.backgroundColor}
+                        divider={drawerFooterProps.divider}
+                        hideContentOnCollapse={drawerFooterProps.hideContentOnCollapse}
+                    >
+                        <Box sx={{ p: 2 }}>Footer Content Here</Box>
+                    </DrawerFooter>
+                </Drawer>
+            }
+            code={generateCodeSnippet()}
+        />
+    );
+};

--- a/docs/src/componentDocs/DrawerFooter/playground/PropsPlayground.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/PropsPlayground.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { RootState } from '../../../redux/store';
+import { useAppSelector } from '../../../redux/hooks';
+import PlaygroundDrawer from '../../../shared/PlaygroundDrawer';
+
+const PropsPlayground = (): JSX.Element => {
+    const drawerFooterJson = useAppSelector((state: RootState) => state.componentsPropsState.drawerFooterComponent);
+
+    return <PlaygroundDrawer drawerData={drawerFooterJson} />;
+};
+
+export default PropsPlayground;

--- a/docs/src/componentDocs/DrawerFooter/playground/index.tsx
+++ b/docs/src/componentDocs/DrawerFooter/playground/index.tsx
@@ -1,0 +1,2 @@
+export * from './PlaygroundPage';
+export * from './PreviewComponent';

--- a/docs/src/redux/componentsPropsState.tsx
+++ b/docs/src/redux/componentsPropsState.tsx
@@ -2,17 +2,20 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import drawerTypes from '../componentDocs/Drawer/playground/DrawerTypes';
 import drawerHeaderTypes from '../componentDocs/DrawerHeader/playground/DrawerHeaderTypes';
 import drawerSubheaderTypes from '../componentDocs/DrawerSubheader/playground/DrawerSubheaderTypes';
+import DrawerFooterTypes from '../componentDocs/DrawerFooter/playground/DrawerFooterTypes';
 import { getComponentState } from '../shared/utilities';
 import { PayloadType, ComponentType } from '../__types__';
 type ComponentState = {
     drawerComponent: ComponentType;
     drawerHeaderComponent: ComponentType;
     drawerSubheaderComponent: ComponentType;
+    drawerFooterComponent: ComponentType;
 };
 const initialState: ComponentState = {
     drawerComponent: drawerTypes,
     drawerHeaderComponent: drawerHeaderTypes,
     drawerSubheaderComponent: drawerSubheaderTypes,
+    drawerFooterComponent: DrawerFooterTypes,
 };
 export const componentPropsStateSlice = createSlice({
     name: 'componentsPropsState',

--- a/docs/src/shared/utilities.tsx
+++ b/docs/src/shared/utilities.tsx
@@ -4,6 +4,7 @@ import FitnessCenter from '@mui/icons-material/FitnessCenter';
 import Menu from '@mui/icons-material/Menu';
 import PinDrop from '@mui/icons-material/PinDrop';
 import Remove from '@mui/icons-material/Remove';
+import { RootState } from '../redux/store';
 import { ComponentType, PropsType } from '../__types__';
 
 export const getSnakeCase = (str: string): string => str.replace(/[A-Z]/g, '_$&').toLowerCase().slice(1);
@@ -75,7 +76,7 @@ export const createProps = (props: PropsType[]): any => {
     return componentProps;
 };
 
-export const getComponentState = (componentName: string, state: any): ComponentType => {
+export const getComponentState = (componentName: string, state: RootState['componentsPropsState']): ComponentType => {
     switch (componentName) {
         case 'Drawer Header':
             return state.drawerHeaderComponent;
@@ -83,6 +84,8 @@ export const getComponentState = (componentName: string, state: any): ComponentT
             return state.drawerComponent;
         case 'Drawer Subheader':
             return state.drawerSubheaderComponent;
+        case 'Drawer Footer':
+            return state.drawerFooterComponent;
         default:
             return state.drawerComponent;
     }


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes 3418 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Footer Playground
- Footer hideContentOnCollapse prop issue fixed [here](https://github.com/brightlayer-ui/react-component-library/pull/495)
- **Need to merge after [Drawer Subheader playground PR]**(https://github.com/brightlayer-ui/react-component-library/pull/494)

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1492" alt="Screenshot 2022-09-02 at 3 23 18 PM" src="https://user-images.githubusercontent.com/10433274/188114224-84744918-ccbd-4d03-80b4-e8658bfb0f40.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- http://localhost:3001/components/drawer-footer/playground
