### PR TITLE
fix hideContentOnCollapse prop of DrawerFooter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v6.1.1 (Unreleased)
+
+### Fixed
+
+-   `hideContentOnCollapse` prop of `<DrawerFooter>` not hiding footer content ([#486](https://github.com/brightlayer-ui/react-component-library/issues/484)).
 ## v6.1.0 (June 24, 2022)
 
 ### Changed

--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-components",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "description": "React components for Brightlayer UI applications",
     "scripts": {
         "test": "jest src",

--- a/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
+++ b/components/src/core/Drawer/DrawerFooter/DrawerFooter.tsx
@@ -48,7 +48,7 @@ const Root = styled(Box, {
 })<Pick<DrawerFooterProps, 'backgroundColor'>>(({ backgroundColor }) => ({
     width: '100%',
     backgroundColor: backgroundColor,
-    [`& .${drawerFooterClasses.hidden}`]: {
+    [`&.${drawerFooterClasses.hidden}`]: {
         visibility: 'hidden',
     },
 }));


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [484](https://github.com/brightlayer-ui/react-component-library/issues/484) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- fix hideContentOnCollapse prop of DrawerFooter

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
![hide_footer_content](https://user-images.githubusercontent.com/10433274/188120305-610321d2-c7c9-42c4-98d5-114e7da3cfdf.gif)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase
- /templates/dashboard
- Click on hamburger icon from drawer header. It will collapsed drawer content and footer content should be hidden

