### PR TITLE
Removed  open prop from shouldForwardProp drawer root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixed
 
--   `hideContentOnCollapse` prop of `<DrawerFooter>` not hiding footer content ([#486](https://github.com/brightlayer-ui/react-component-library/issues/484)).
+-   `hideContentOnCollapse` prop of `<DrawerFooter>` not hiding footer content ([#484](https://github.com/brightlayer-ui/react-component-library/issues/484)).
+-   Temporary drawer rendering, due to incorrectly passing open prop ([#486](https://github.com/brightlayer-ui/react-component-library/issues/486)).
+
 ## v6.1.0 (June 24, 2022)
 
 ### Changed

--- a/components/src/core/Drawer/Drawer.tsx
+++ b/components/src/core/Drawer/Drawer.tsx
@@ -96,7 +96,7 @@ export type DrawerComponentProps = DrawerProps; // alias
 const Root = styled(MUIDrawer, {
     name: 'drawer',
     slot: 'root',
-    shouldForwardProp: (prop) => prop !== 'backgroundColor' && prop !== 'sideBorder' && prop !== 'open',
+    shouldForwardProp: (prop) => prop !== 'backgroundColor' && prop !== 'sideBorder',
 })<Pick<DrawerProps, 'backgroundColor' | 'sideBorder' | 'open'>>(({ backgroundColor, sideBorder, open, theme }) => ({
     minHeight: '100%',
     backgroundColor: backgroundColor || 'transparent',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #486 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Removed open prop from shouldForwardProp in Drawer Root

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
**Before**
<img width="1792" alt="Screenshot 2022-08-30 at 2 58 08 PM" src="https://user-images.githubusercontent.com/25982779/187404057-b11af1f9-7c85-4037-afdb-597bb9826f5e.png">

**After**
<img width="1792" alt="Screenshot 2022-08-30 at 3 08 10 PM" src="https://user-images.githubusercontent.com/25982779/187404189-c6b51b25-91ab-4b11-8b5d-4c34733f1eb8.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:showcase

**Note: temporary variant of drawer by default takes open prop as false, so to test this we need to pass open prop in Drawer Root element as true and in NavigationDrawer we need to change the variant to temporary **
