### PR TITLE
Added CodeBlockActionButtonRow in place of gihub button and code block

### DIFF
--- a/docs/src/componentDocs/Drawer/examples/BasicDrawer.tsx
+++ b/docs/src/componentDocs/Drawer/examples/BasicDrawer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { BasicDrawerExample } from './BasicDrawerExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -25,9 +25,6 @@ export const BasicDrawer = (): JSX.Element => (
     <Box>
         <BasicDrawerExample />
         <CodeBlock code={codeSnippet} language="jsx" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub sx={{ ml: 2 }} url="componentDocs/Drawer/examples/BasicDrawerExample.tsx" />
-        </Box>
+        <CodeBlockActionButtonRow copyText={codeSnippet} url="componentDocs/Drawer/examples/BasicDrawerExample.tsx" />
     </Box>
 );

--- a/docs/src/componentDocs/Drawer/examples/ComplexDrawer.tsx
+++ b/docs/src/componentDocs/Drawer/examples/ComplexDrawer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { ComplexDrawerExample } from './ComplexDrawerExample';
 
 const codeSnippet = `<Drawer open={true} width={300}>
@@ -48,9 +48,6 @@ export const ComplexDrawer = (): JSX.Element => (
     <Box>
         <ComplexDrawerExample />
         <CodeBlock code={codeSnippet} language="jsx" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub sx={{ ml: 2 }} url="componentDocs/Drawer/examples/ComplexDrawerExample.tsx" />
-        </Box>
+        <CodeBlockActionButtonRow copyText={codeSnippet} url="componentDocs/Drawer/examples/ComplexDrawerExample.tsx" />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerHeader/examples/BasicDrawerHeader.tsx
+++ b/docs/src/componentDocs/DrawerHeader/examples/BasicDrawerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { BasicDrawerHeaderExample } from './BasicDrawerHeaderExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -12,9 +12,9 @@ export const BasicDrawerHeader = (): JSX.Element => (
     <Box>
         <BasicDrawerHeaderExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub sx={{ ml: 2 }} url="componentDocs/DrawerHeader/examples/BasicDrawerHeaderExample.tsx" />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerHeader/examples/BasicDrawerHeaderExample.tsx"
+        />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithIcon.tsx
+++ b/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { DrawerHeaderWithIconExample } from './DrawerHeaderWithIconExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -12,12 +12,9 @@ export const DrawerHeaderWithIcon = (): JSX.Element => (
     <Box>
         <DrawerHeaderWithIconExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub
-                sx={{ ml: 2 }}
-                url="componentDocs/DrawerHeader/examples/DrawerHeaderWithIconExample.tsx"
-            />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerHeader/examples/DrawerHeaderWithIconExample.tsx"
+        />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithSubtitle.tsx
+++ b/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithSubtitle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { DrawerHeaderWithSubtitleExample } from './DrawerHeaderWithSubtitleExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -12,12 +12,9 @@ export const DrawerHeaderWithSubtitle = (): JSX.Element => (
     <Box>
         <DrawerHeaderWithSubtitleExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub
-                sx={{ ml: 2 }}
-                url="componentDocs/DrawerHeader/examples/DrawerHeaderWithSubtitleExample.tsx"
-            />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerHeader/examples/DrawerHeaderWithSubtitleExample.tsx"
+        />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithTitleContent.tsx
+++ b/docs/src/componentDocs/DrawerHeader/examples/DrawerHeaderWithTitleContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { DrawerHeaderWithTitleContentExample } from './DrawerHeaderWithTitleContentExample';
 
 const codeSnippet = ` <Drawer open={true} width={250}>
@@ -22,12 +22,9 @@ export const DrawerHeaderWithTitleContent = (): JSX.Element => (
     <Box>
         <DrawerHeaderWithTitleContentExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2-12" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub
-                sx={{ ml: 2 }}
-                url="componentDocs/DrawerHeader/examples/DrawerHeaderWithTitleContentExample.tsx"
-            />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerHeader/examples/DrawerHeaderWithTitleContentExample.tsx"
+        />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerSubheader/examples/BasicDrawerSubheader.tsx
+++ b/docs/src/componentDocs/DrawerSubheader/examples/BasicDrawerSubheader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { BasicDrawerSubheaderExample } from './BasicDrawerSubheaderExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -15,12 +15,9 @@ export const BasicDrawerSubheader = (): JSX.Element => (
     <Box>
         <BasicDrawerSubheaderExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="3-5" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub
-                sx={{ ml: 2 }}
-                url="componentDocs/DrawerSubheader/examples/BasicDrawerSubheaderExample.tsx"
-            />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerSubheader/examples/BasicDrawerSubheaderExample.tsx"
+        />
     </Box>
 );

--- a/docs/src/componentDocs/DrawerSubheader/examples/ComplexDrawerSubheader.tsx
+++ b/docs/src/componentDocs/DrawerSubheader/examples/ComplexDrawerSubheader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
-import { CodeBlock, CopyToClipboard, FullCodeOnGithub } from '../../../shared';
+import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
 import { ComplexDrawerSubheaderExample } from './ComplexDrawerSubheaderExample';
 
 const codeSnippet = `<Drawer open={true} width={250}>
@@ -39,9 +39,9 @@ export const ComplexDrawerSubheader = (): JSX.Element => (
     <Box>
         <ComplexDrawerSubheaderExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="3-22" />
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1 }}>
-            <CopyToClipboard title={'Copy All'} copyText={codeSnippet} />
-            <FullCodeOnGithub sx={{ ml: 2 }} url="componentDocs/DrawerSubheader/examples/ComplexDrawerSubheader.tsx" />
-        </Box>
+        <CodeBlockActionButtonRow
+            copyText={codeSnippet}
+            url="componentDocs/DrawerSubheader/examples/ComplexDrawerSubheader.tsx"
+        />
     </Box>
 );

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 import Box from '@mui/material/Box/Box';
-import { CodeBlock } from './CodeBlock';
-import { CodeBlockActionButtonRow } from './CodeBlockActionButtonRow';
+import { CodeBlock, CopyToClipboard } from '.';
 import * as Colors from '@brightlayer-ui/colors';
 
 export type PreviewComponentProps = HTMLAttributes<HTMLDivElement> & {
@@ -38,7 +37,6 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                 onMouseLeave={(): void => setShow(false)}
             >
                 <CodeBlock code={code} language="jsx" />
-
                 <Box
                     sx={{
                         position: 'absolute',
@@ -46,7 +44,7 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                         right: '400px',
                     }}
                 >
-                    {show && <CodeBlockActionButtonRow copyText={code} />}
+                    {show && <CopyToClipboard title={'Copy All'} copyText={code} />}
                 </Box>
             </Box>
         </>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3425

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Added CodeBlockActionButtonRow instead of separate Codeblock and Github components

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1792" alt="Screenshot 2022-09-19 at 7 26 27 PM" src="https://user-images.githubusercontent.com/25982779/191034445-2d8e136b-e833-4213-870b-72958b339b54.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:reactdev

**Note: This PR is for using componentized button row for codeblock and github**
