### PR TITLE
Feature/3532 copy code button color

### DIFF
--- a/docs/src/shared/CodeBlock.tsx
+++ b/docs/src/shared/CodeBlock.tsx
@@ -1,6 +1,8 @@
 import React, { HTMLAttributes, useEffect } from 'react';
 import Prism from 'prismjs';
 import Box from '@mui/material/Box';
+import * as Colors from '@brightlayer-ui/colors';
+
 export type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
     code: string;
     language: string;
@@ -27,7 +29,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = (props): JSX.Element => {
             {...divProps}
             className="Code"
         >
-            <pre data-line={dataLine} style={{ margin: 0, width: '100%' }}>
+            <pre data-line={dataLine} style={{ margin: 0, width: '100%', backgroundColor: Colors.black[800] }}>
                 <code style={{ fontFamily: 'monospace' }} className={`language-${language}`}>
                     {code}
                 </code>

--- a/docs/src/shared/CopyToClipboardButton.tsx
+++ b/docs/src/shared/CopyToClipboardButton.tsx
@@ -5,8 +5,14 @@ import { isMobile } from 'react-device-detect';
 import CopyAllIcon from '@mui/icons-material/CopyAll';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import { Theme, SxProps } from '@mui/material/styles';
 
 type Position = 'bottom' | 'top' | 'left' | 'right';
+
+type CopyButtonProps = {
+    sx?: SxProps<Theme>;
+};
+
 type CopyToClipboardProps = {
     duration?: number;
     position?: Position;
@@ -14,10 +20,19 @@ type CopyToClipboardProps = {
     copiedTitle?: string;
     copyText: string;
     toolTipProps?: TooltipProps;
+    copyButtonProps?: CopyButtonProps;
 };
 
 export const CopyToClipboard: React.FC<CopyToClipboardProps> = (props) => {
-    const { duration = 1000, position = 'bottom', title = '', copiedTitle = 'Copied', copyText, toolTipProps } = props;
+    const {
+        duration = 1000,
+        position = 'bottom',
+        title = '',
+        copiedTitle = 'Copied',
+        copyText,
+        toolTipProps,
+        copyButtonProps,
+    } = props;
     const [isCopied, setIsCopied] = useState(false);
     const [showTooltip, setShowTooltip] = useState(false);
 
@@ -43,6 +58,8 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = (props) => {
                         });
                     }}
                     startIcon={<CopyAllIcon />}
+                    {...copyButtonProps}
+                    sx={{ ...copyButtonProps?.sx }}
                 >
                     Copy All
                 </Button>

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -51,7 +51,7 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                                     color: Colors.blue[200],
                                     borderColor: Colors.blue[200],
                                     backgroundColor: Colors.black[800],
-                                    '&:hover': { borderColor: Colors.blue[200], backgroundColor: 'inherit' },
+                                    '&:hover': { borderColor: Colors.blue[200], backgroundColor: Colors.black[800] },
                                 },
                             }}
                             title={'Copy All'}

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -44,7 +44,20 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
                         right: '400px',
                     }}
                 >
-                    {show && <CopyToClipboard title={'Copy All'} copyText={code} />}
+                    {show && (
+                        <CopyToClipboard
+                            copyButtonProps={{
+                                sx: {
+                                    color: Colors.blue[200],
+                                    borderColor: Colors.blue[200],
+                                    backgroundColor: Colors.black[800],
+                                    '&:hover': { borderColor: Colors.blue[200], backgroundColor: 'inherit' },
+                                },
+                            }}
+                            title={'Copy All'}
+                            copyText={code}
+                        />
+                    )}
                 </Box>
             </Box>
         </>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3532 #540 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Updated the code block background color to black 800
- Updated code block copy button color to blue 200

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1792" alt="Screenshot 2022-09-30 at 4 49 58 PM" src="https://user-images.githubusercontent.com/25982779/193258911-0fef2086-e72a-4492-b337-c3046d54da53.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:reactdev
