### PR TITLE
Feature/3552 app bar example clean up

### DIFF
--- a/docs/src/componentDocs/AppBar/examples/AppBar.tsx
+++ b/docs/src/componentDocs/AppBar/examples/AppBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
-import { SnapAppBarExample } from './SnapAppBarExample';
+import { AppBarExample } from './AppBarExample';
 
 const codeSnippet = `<Box>
     <AppBar
@@ -19,10 +19,10 @@ const codeSnippet = `<Box>
 </Box>
 `;
 
-export const SnapAppBar = (): JSX.Element => (
+export const AppBar = (): JSX.Element => (
     <Box>
-        <SnapAppBarExample />
+        <AppBarExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2-10" />
-        <CodeBlockActionButtonRow copyText={codeSnippet} url="componentDocs/AppBar/examples/SnapAppBarExample.tsx" />
+        <CodeBlockActionButtonRow copyText={codeSnippet} url="componentDocs/AppBar/examples/AppBarExample.tsx" />
     </Box>
 );

--- a/docs/src/componentDocs/AppBar/examples/AppBarExample.tsx
+++ b/docs/src/componentDocs/AppBar/examples/AppBarExample.tsx
@@ -4,8 +4,8 @@ import * as colors from '@brightlayer-ui/colors';
 import { AppBar } from '@brightlayer-ui/react-components';
 import { getBodyFiller } from '../../../shared';
 
-export const SnapAppBarExample = (): JSX.Element => (
-    <Box sx={{ m: '16px 0', backgroundColor: colors.white[600], p: 4, overflow: 'hidden' }}>
+export const AppBarExample = (): JSX.Element => (
+    <Box sx={{ my: 2, backgroundColor: colors.white[600], p: 4, overflow: 'hidden' }}>
         <Box sx={{ mb: 2, overflow: 'hidden', height: 400 }}>
             <AppBar
                 variant="snap"

--- a/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContent.tsx
+++ b/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContent.tsx
@@ -43,7 +43,7 @@ const codeSnippet = `<Box>
 export const AppBarWithAdditionalContent = (): JSX.Element => (
     <Box>
         <AppBarWithAdditionalContentExample />
-        <CodeBlock code={codeSnippet} language="jsx" dataLine="2-31" />
+        <CodeBlock code={codeSnippet} language="jsx" dataLine="8-30" />
         <CodeBlockActionButtonRow
             copyText={codeSnippet}
             url="componentDocs/AppBar/examples/AppBarWithAdditionalContentExample.tsx"

--- a/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContent.tsx
+++ b/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import { CodeBlock, CodeBlockActionButtonRow } from '../../../shared';
-import { CustomContentAppBarExample } from './CustomContentAppBarExample';
+import { AppBarWithAdditionalContentExample } from './AppBarWithAdditionalContentExample';
 
 const codeSnippet = `<Box>
     <AppBar
@@ -40,13 +40,13 @@ const codeSnippet = `<Box>
 </Box>
 `;
 
-export const CustomContentAppBar = (): JSX.Element => (
+export const AppBarWithAdditionalContent = (): JSX.Element => (
     <Box>
-        <CustomContentAppBarExample />
+        <AppBarWithAdditionalContentExample />
         <CodeBlock code={codeSnippet} language="jsx" dataLine="2-31" />
         <CodeBlockActionButtonRow
             copyText={codeSnippet}
-            url="componentDocs/AppBar/examples/CustomContentAppBarExample.tsx"
+            url="componentDocs/AppBar/examples/AppBarWithAdditionalContentExample.tsx"
         />
     </Box>
 );

--- a/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContentExample.tsx
+++ b/docs/src/componentDocs/AppBar/examples/AppBarWithAdditionalContentExample.tsx
@@ -6,8 +6,8 @@ import { getBodyFiller } from '../../../shared';
 import { Download, Menu, MoreVert, Search } from '@mui/icons-material';
 import BackgroundImage from '../images/farm.jpg';
 
-export const CustomContentAppBarExample = (): JSX.Element => (
-    <Box sx={{ m: '16px 0', backgroundColor: colors.white[600], p: 4, overflow: 'hidden' }}>
+export const AppBarWithAdditionalContentExample = (): JSX.Element => (
+    <Box sx={{ my: 2, backgroundColor: colors.white[600], p: 4, overflow: 'hidden' }}>
         <Box sx={{ mb: 2, overflow: 'hidden', height: 400 }}>
             <AppBar
                 classes={{ collapsed: 'collapsed', expanded: 'expanded' }}

--- a/docs/src/componentDocs/AppBar/examples/CollapsedAppBarExample.tsx
+++ b/docs/src/componentDocs/AppBar/examples/CollapsedAppBarExample.tsx
@@ -5,7 +5,7 @@ import { AppBar } from '@brightlayer-ui/react-components';
 import { getBodyFiller } from '../../../shared';
 
 export const CollapsedAppBarExample = (): JSX.Element => (
-    <Box sx={{ m: '16px 0', backgroundColor: colors.white[600], p: 4 }}>
+    <Box sx={{ my: 2, backgroundColor: colors.white[600], p: 4 }}>
         <AppBar collapsedHeight={64} variant={'collapsed'} sx={{ width: 450, mx: 'auto', zIndex: 'auto' }}>
             <Toolbar>
                 <Typography variant="h6">Content</Typography>

--- a/docs/src/componentDocs/AppBar/examples/ExpandedAppBarExample.tsx
+++ b/docs/src/componentDocs/AppBar/examples/ExpandedAppBarExample.tsx
@@ -5,7 +5,7 @@ import { AppBar } from '@brightlayer-ui/react-components';
 import { getBodyFiller } from '../../../shared';
 
 export const ExpandedAppBarExample = (): JSX.Element => (
-    <Box sx={{ m: '16px 0', backgroundColor: colors.white[600], p: 4 }}>
+    <Box sx={{ my: 2, backgroundColor: colors.white[600], p: 4 }}>
         <AppBar collapsedHeight={64} variant={'expanded'} sx={{ width: 450, mx: 'auto', zIndex: 'auto' }}>
             <Toolbar>
                 <Typography variant="h6">Content</Typography>

--- a/docs/src/componentDocs/AppBar/examples/index.tsx
+++ b/docs/src/componentDocs/AppBar/examples/index.tsx
@@ -1,0 +1,4 @@
+export * from './AppBar';
+export * from './AppBarWithAdditionalContent';
+export * from './CollapsedAppBar';
+export * from './ExpandedAppBar';

--- a/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
@@ -8,13 +8,13 @@ An `<AppBar>` is an extension of the [`MUI Toolbar`](https://mui.com/material-ui
 
 ## Permanently Collapsed
 
-Setting the variant to `collapsed` will lock the App Bar at its collapsed size and it will behave like a default toolbar.
+Setting the variant to 'collapsed' will lock the App Bar at its collapsed size and it will behave like a default toolbar.
 
 <CollapsedAppBar />
 
 ## Permanently Expanded
 
-Setting the variant to `expanded` will lock the App Bar at its expanded size.
+Setting the variant to 'expanded' will lock the App Bar at its expanded size.
 
 <ExpandedAppBar />
 

--- a/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
@@ -3,30 +3,26 @@ import { ExpandedAppBar } from '../examples/ExpandedAppBar';
 import { SnapAppBar } from '../examples/SnapAppBar';
 import { CustomContentAppBar } from '../examples/CustomContentAppBar';
 
-# App Bar
+## Collapsible App Bar
 
-An `<AppBar>` supports multiple variants - `collapsed`, `expanded`, and `snap`.
-
-# Collapsed Variant
-
-An `<AppBar>` with a `collapsed` variant will stay fixed at the `collapsedHeight` size.
-
-<CollapsedAppBar />
-
-# Expanded Variant
-
-An `<AppBar>` with an `expanded` variant will stay fixed at the `expandedHeight` size.
-
-<ExpandedAppBar />
-
-# Snap Variant
-
-An `<AppBar>` will resize between `collapsedHeight` and `expandedHeight` as the window is scrolled.
+An `<AppBar>` is an extension of the [`MUI Toolbar`](https://mui.com/material-ui/api/toolbar/) that can expand and collapse as you scroll the page.
 
 <SnapAppBar />
 
-# App Bar with Custom Content
+## Permanently Collapsed
 
-An `<AppBar>` can accept an icon, actions and custom content.
+Setting the variant to `collapsed` will lock the App Bar at its collapsed size and it will behave like a default toolbar.
+
+<CollapsedAppBar />
+
+## Permanently Expanded
+
+Setting the variant to `expanded` will lock the App Bar at its expanded size.
+
+<ExpandedAppBar />
+
+## Adding Additional Content
+
+You can organize the contents of your App Bar by adding a [`Toolbar`](https://mui.com/material-ui/api/toolbar/) component, just as you would with a [`MUI App Bar`](https://mui.com/material-ui/api/app-bar/) component.
 
 <CustomContentAppBar />

--- a/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
@@ -1,13 +1,10 @@
-import { CollapsedAppBar } from '../examples/CollapsedAppBar';
-import { ExpandedAppBar } from '../examples/ExpandedAppBar';
-import { SnapAppBar } from '../examples/SnapAppBar';
-import { CustomContentAppBar } from '../examples/CustomContentAppBar';
+import { AppBar, CollapsedAppBar, ExpandedAppBar, AppBarWithAdditionalContent } from '../examples';
 
 ## Collapsible App Bar
 
 An `<AppBar>` is an extension of the [`MUI Toolbar`](https://mui.com/material-ui/api/toolbar/) that can expand and collapse as you scroll the page.
 
-<SnapAppBar />
+<AppBar />
 
 ## Permanently Collapsed
 
@@ -25,4 +22,4 @@ Setting the variant to `expanded` will lock the App Bar at its expanded size.
 
 You can organize the contents of your App Bar by adding a [`Toolbar`](https://mui.com/material-ui/api/toolbar/) component, just as you would with a [`MUI App Bar`](https://mui.com/material-ui/api/app-bar/) component.
 
-<CustomContentAppBar />
+<AppBarWithAdditionalContent />

--- a/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
+++ b/docs/src/componentDocs/AppBar/markdown/AppBarExamples.mdx
@@ -8,13 +8,13 @@ An `<AppBar>` is an extension of the [`MUI Toolbar`](https://mui.com/material-ui
 
 ## Permanently Collapsed
 
-Setting the variant to 'collapsed' will lock the App Bar at its collapsed size and it will behave like a default toolbar.
+Setting the variant to `'collapsed'` will lock the App Bar at its collapsed size and it will behave like a default toolbar.
 
 <CollapsedAppBar />
 
 ## Permanently Expanded
 
-Setting the variant to 'expanded' will lock the App Bar at its expanded size.
+Setting the variant to `'expanded'` will lock the App Bar at its expanded size.
 
 <ExpandedAppBar />
 

--- a/docs/src/shared/CodeBlockActionButtonRow.tsx
+++ b/docs/src/shared/CodeBlockActionButtonRow.tsx
@@ -23,7 +23,6 @@ export const CodeBlockActionButtonRow: React.FC<CodeBlockActionButtonRowProps> =
 
     return (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1, ...sx }}>
-            {url !== '' && <FullCodeOnGithub sx={{ ml: 1 }} url={url} />}
             {copyText !== '' && (
                 <CopyToClipboard
                     title={title}
@@ -34,6 +33,7 @@ export const CodeBlockActionButtonRow: React.FC<CodeBlockActionButtonRowProps> =
                     toolTipProps={props.toolTipProps}
                 />
             )}
+            {url !== '' && <FullCodeOnGithub sx={{ ml: 1 }} url={url} />}
         </Box>
     );
 };

--- a/docs/src/shared/CodeBlockActionButtonRow.tsx
+++ b/docs/src/shared/CodeBlockActionButtonRow.tsx
@@ -23,6 +23,7 @@ export const CodeBlockActionButtonRow: React.FC<CodeBlockActionButtonRowProps> =
 
     return (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 1, ...sx }}>
+            {url !== '' && <FullCodeOnGithub sx={{ ml: 1 }} url={url} />}
             {copyText !== '' && (
                 <CopyToClipboard
                     title={title}
@@ -33,7 +34,6 @@ export const CodeBlockActionButtonRow: React.FC<CodeBlockActionButtonRowProps> =
                     toolTipProps={props.toolTipProps}
                 />
             )}
-            {url !== '' && <FullCodeOnGithub sx={{ ml: 1 }} url={url} />}
         </Box>
     );
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3552

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
App Bar
Examples
Start with the snap example
Custom content description doesn't make sense — this one will be different from Angular….the react implementation works like a normal app bar, whereas the Angular one has specific content projection slots — reach out to me and I'll help with the description

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1792" alt="Screenshot 2022-10-12 at 4 15 11 PM 1" src="https://user-images.githubusercontent.com/25982779/195323354-845d1b95-603b-4c45-8c46-4ed43308f3eb.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- yarn start:reactdev
- Navigate to App Bar
