### PR TITLE
Fix overflow on playground

### DIFF
--- a/docs/src/componentDocs/Drawer/playground/DrawerConfig.tsx
+++ b/docs/src/componentDocs/Drawer/playground/DrawerConfig.tsx
@@ -66,7 +66,7 @@ export const drawerConfig: ComponentType = {
         {
             propName: 'variant',
             inputType: 'select',
-            inputValue: 'permanent',
+            inputValue: 'persistent',
             options: ['persistent', 'permanent', 'temporary', 'rail'],
             propType: 'string',
             helperText: `The variant to use from options 'persistent', 'permanent', 'temporary', 'rail'`,

--- a/docs/src/shared/ComponentPreviewTabs.tsx
+++ b/docs/src/shared/ComponentPreviewTabs.tsx
@@ -36,7 +36,6 @@ function togglePlaygroundTab(location: string): boolean {
 }
 
 const tabStyles = {
-    // width: '100%',
     flex: 1,
     color: 'text.primary',
     '&.Mui-selected': {

--- a/docs/src/shared/ComponentPreviewTabs.tsx
+++ b/docs/src/shared/ComponentPreviewTabs.tsx
@@ -36,7 +36,8 @@ function togglePlaygroundTab(location: string): boolean {
 }
 
 const tabStyles = {
-    width: '100%',
+    // width: '100%',
+    flex: 1,
     color: 'text.primary',
     '&.Mui-selected': {
         color: 'primary.main',
@@ -102,42 +103,13 @@ export const ComponentPreviewTabs = (): JSX.Element => {
                     },
                 }}
             >
-                <Tab
-                    to="examples"
-                    component={Link}
-                    sx={{
-                        ...tabStyles,
-                        [theme.breakpoints.down(1040)]: {
-                            width: '33%',
-                        },
-                    }}
-                    label="Examples"
-                    replace={true}
-                    {...a11yProps(0)}
-                />
-                <Tab
-                    to="api-docs"
-                    component={Link}
-                    sx={{
-                        ...tabStyles,
-                        [theme.breakpoints.down(1040)]: {
-                            width: '33%',
-                        },
-                    }}
-                    label="API Docs"
-                    replace={true}
-                    {...a11yProps(1)}
-                />
+                <Tab to="examples" component={Link} sx={tabStyles} label="Examples" replace={true} {...a11yProps(0)} />
+                <Tab to="api-docs" component={Link} sx={tabStyles} label="API Docs" replace={true} {...a11yProps(1)} />
                 {!hidePlaygroundTab && (
                     <Tab
                         to="playground"
                         component={Link}
-                        sx={{
-                            ...tabStyles,
-                            [theme.breakpoints.down(1040)]: {
-                                width: '33%',
-                            },
-                        }}
+                        sx={tabStyles}
                         label="Playground"
                         replace={true}
                         {...a11yProps(2)}

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -17,11 +17,10 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
             <Box
                 sx={{
                     p: 2,
-                    height: '70vh',
+                    height: { xs: 'calc(70vh - 105px)', sm: 'calc(70vh - 113px)' },
                     display: 'flex',
                     justifyContent: 'center',
                     alignItems: 'center',
-                    mt: 6,
                     bgcolor: Colors.white[200],
                 }}
             >

--- a/docs/src/shared/PreviewComponentWithCode.tsx
+++ b/docs/src/shared/PreviewComponentWithCode.tsx
@@ -17,6 +17,10 @@ const PreviewComponentWithCode: React.FC<PreviewComponentProps> = (props): JSX.E
             <Box
                 sx={{
                     p: 2,
+                    /**
+                     * We take the height of the appbar/tabs out of the 70vh portion
+                     * 64px (56 on xs) for AppBar + 49px for Tabs = 113/105
+                     * */
                     height: { xs: 'calc(70vh - 105px)', sm: 'calc(70vh - 113px)' },
                     display: 'flex',
                     justifyContent: 'center',


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Fix overflow on playground caused by updated Tabs position value
  - the strange numbers are because the tab bar renders at 49px tall
- Fix issue where tabs overflow under the nav drawer on medium size screens

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="1402" alt="image" src="https://user-images.githubusercontent.com/29152776/199243766-772711d5-d7e7-4369-b995-9566978661ae.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Verify that the playground does not scroll vertically
- Verify that the tabs are all fully visible across all screen sizes
