### PR TITLE
update subheader preview indentation

### DIFF
--- a/docs/src/componentDocs/DrawerSubheader/playground/PreviewComponent.tsx
+++ b/docs/src/componentDocs/DrawerSubheader/playground/PreviewComponent.tsx
@@ -31,50 +31,50 @@ export const PreviewComponent = (): JSX.Element => {
             return `<DrawerSubheader>`;
         }
         return `<DrawerSubheader 
-            ${toggleDefaultProp('divider', drawerSubheaderProps.divider)}
-            ${toggleDefaultProp('hideContentOnCollapse', drawerSubheaderProps.hideContentOnCollapse)}
-        >`;
+        ${toggleDefaultProp('divider', drawerSubheaderProps.divider)}
+        ${toggleDefaultProp('hideContentOnCollapse', drawerSubheaderProps.hideContentOnCollapse)}
+    >`;
     };
 
     const generateCodeSnippet = (): string => {
         const jsx = `<Drawer open={${drawerSubheaderOtherProps.open}}>
-        <DrawerHeader 
-            icon={<Menu />}
-            title={'Subheader Demo'}
-            subtitle={'See the DrawerSubheader below'} 
-        />
-        ${generateSubHeaderSnippet()}
-            <Box
-                sx={{
-                    p: 2,
-                }}
-            >
-                Subheader Content Here
-            </Box>
-        </DrawerSubheader>
-        <DrawerBody>
-            <DrawerNavGroup>
-                <DrawerNavItem
-                    icon={<Person />}
-                    itemID={'Identity Management'}
-                    title={'Identity Management'}
-                />
-                <DrawerNavItem
-                    icon={<Today />}
-                    itemID={'Calendar'}
-                    title={'Calendar'} />
-                <DrawerNavItem 
-                    icon={<Accessibility />}
-                    title={'Accessibility'}
-                    itemID={'Accessibility'} />
-                <DrawerNavItem
-                    icon={<NotificationsActive />}
-                    title={'Notifications'}
-                    itemID={'Notifications'}
-                />
-            </DrawerNavGroup>
-        </DrawerBody>
-    </Drawer>`;
+    <DrawerHeader 
+        icon={<Menu />}
+        title={'Subheader Demo'}
+        subtitle={'See the DrawerSubheader below'} 
+    />
+    ${generateSubHeaderSnippet()}
+        <Box
+            sx={{
+                p: 2,
+            }}
+        >
+            Subheader Content Here
+        </Box>
+    </DrawerSubheader>
+    <DrawerBody>
+        <DrawerNavGroup>
+            <DrawerNavItem
+                icon={<Person />}
+                itemID={'Identity Management'}
+                title={'Identity Management'}
+            />
+            <DrawerNavItem
+                icon={<Today />}
+                itemID={'Calendar'}
+                title={'Calendar'} />
+            <DrawerNavItem 
+                icon={<Accessibility />}
+                title={'Accessibility'}
+                itemID={'Accessibility'} />
+            <DrawerNavItem
+                icon={<NotificationsActive />}
+                title={'Notifications'}
+                itemID={'Notifications'}
+            />
+        </DrawerNavGroup>
+    </DrawerBody>
+</Drawer>`;
 
         return removeEmptyLines(jsx);
     };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes https://github.com/brightlayer-ui/react-component-library/issues/579 . this issue was fixed in other work and no longer a problem. This PR fixes the drawer subheader playground code snippet indentation found during reviewing

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Update indentation for code snippet for DrawerSubheader
- 
- 

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
Current code snippet for drawer nav item that is deployed (fixed already)
![image](https://user-images.githubusercontent.com/37150565/208945720-306430fc-1f60-44ed-b456-7c451eb08bb6.png)

This PR fix this...
Old-DrawerSubheader
![image](https://user-images.githubusercontent.com/37150565/208946269-4ed87e99-64f0-4278-9a6c-68748b2053c0.png)

Updated-DrawerSubheader
![image](https://user-images.githubusercontent.com/37150565/208946404-f4dab1db-a373-4ea4-aa9a-d489a5e0fbf3.png)



<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- https://blui-react-docs--pr663-bug-blui-3710-indent-pqrc2mhs.web.app/components/drawer-subheader/playground
