### PR TITLE
Adjust end braces and manually set padding for code snippets

### DIFF
--- a/docs/src/componentDocs/DrawerLayout/examples/DrawerLayout.tsx
+++ b/docs/src/componentDocs/DrawerLayout/examples/DrawerLayout.tsx
@@ -20,7 +20,7 @@ const codeSnippet = `<DrawerLayout
             </DrawerBody>
         </Drawer>
     }
-    >
+>
     <Box>
         App Content Here.
     </Box>

--- a/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithActions.tsx
+++ b/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithActions.tsx
@@ -24,7 +24,7 @@ const codeSnippet = `<ScoreCard
         </HeroBanner>
     }
     badgeOffset={-54}
-    >
+>
     <List>
         <ListItem>
             <ListItemText primary="Body Content" />

--- a/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithHeaderSubtitle.tsx
+++ b/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithHeaderSubtitle.tsx
@@ -8,7 +8,7 @@ const codeSnippet = `<ScoreCard
     headerTitle="Station 3"
     headerSubtitle="High Humidity Alarm"
     headerInfo="4 Devices"
-    >
+>
     <List>
         <ListItem>
             <ListItemText primary="Body Content" />

--- a/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithHeros.tsx
+++ b/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithHeros.tsx
@@ -23,7 +23,7 @@ const codeSnippet = `<ScoreCard
             />
         </HeroBanner>
     }
-    >
+>
     <List>
         <ListItem>
             <ListItemText primary="Body Content" />

--- a/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithScoreBadge.tsx
+++ b/docs/src/componentDocs/ScoreCard/examples/ScoreCardWithScoreBadge.tsx
@@ -20,7 +20,7 @@ const codeSnippet = `<ScoreCard
         </HeroBanner>
     }
     badgeOffset={-54}
-    >
+>
     <List>
         <ListItem>
             <ListItemText primary="Body Content" />

--- a/docs/src/index.css
+++ b/docs/src/index.css
@@ -29,6 +29,12 @@ pre[class*='language-'] * {
     font-family: monospace !important;
 }
 
+pre[class*="language-"] {
+    padding-left: 1em;
+    padding-right: 1rem;
+}
+
+
 /* HIDE INCREMENT/DECREMENT BUTTONS ON NUMBER INPUTS */
 /* Chrome, Safari, Edge, Opera */
 input::-webkit-outer-spin-button,


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Set the padding for code-snippet blocks and make sure closing braces end on the same indentation which the tag began.  

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Firebase deploy should look nice with indents.
